### PR TITLE
fix github action failure and upgrade embuild to v0.30

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Install Rust for Xtensa
-      uses: esp-rs/xtensa-toolchain@v1
+      uses: esp-rs/xtensa-toolchain@v1.2
       with:
-        default: false
-        version: "1.57.0.2"
+        default: true
+        version: "1.60.0"
         ldproxy: true
     - uses: actions/checkout@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ smart-leds = "0.3"
 embedded-graphics = "0.7"
 
 [build-dependencies]
-embuild = "0.28"
+embuild = "0.30"
 anyhow = "1"
 
 [profile.release]


### PR DESCRIPTION
fix build bug where the github action failure at xtensa-elf binary build process where following error message showns:

* fatal: No names found, cannot describe anything.
* error: unknown target triple 'xtensa', please use -triple or -arch
