### PR TITLE
Support for Sk6812 RGBW

### DIFF
--- a/examples/smart_leds_sk6812_rgbw.rs
+++ b/examples/smart_leds_sk6812_rgbw.rs
@@ -1,0 +1,32 @@
+use smart_leds_trait::{SmartLedsWrite, White};
+use std::thread::sleep;
+use std::time::Duration;
+use ws2812_esp32_rmt_driver::driver::color::LedPixelColorGrbw32;
+use ws2812_esp32_rmt_driver::{Ws2812Esp32Rmt, RGBW8};
+
+fn main() -> ! {
+    // Temporary. Will disappear once ESP-IDF 4.4 is released, but for now it is necessary to call this function once,
+    // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
+    esp_idf_sys::link_patches();
+
+    let led_pin = 26;
+    let mut ws2812 = Ws2812Esp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(0, led_pin).unwrap();
+
+    loop {
+        let pixels = std::iter::repeat(RGBW8::from((6, 0, 0, White(0)))).take(25);
+        ws2812.write(pixels).unwrap();
+        sleep(Duration::from_millis(1000));
+
+        let pixels = std::iter::repeat(RGBW8::from((0, 6, 0, White(0)))).take(25);
+        ws2812.write(pixels).unwrap();
+        sleep(Duration::from_millis(1000));
+
+        let pixels = std::iter::repeat(RGBW8::from((0, 0, 6, White(0)))).take(25);
+        ws2812.write(pixels).unwrap();
+        sleep(Duration::from_millis(1000));
+
+        let pixels = std::iter::repeat(RGBW8::from((0, 0, 0, White(6)))).take(25);
+        ws2812.write(pixels).unwrap();
+        sleep(Duration::from_millis(1000));
+    }
+}

--- a/examples/smart_leds_sk6812_rgbw.rs
+++ b/examples/smart_leds_sk6812_rgbw.rs
@@ -2,7 +2,7 @@ use smart_leds_trait::{SmartLedsWrite, White};
 use std::thread::sleep;
 use std::time::Duration;
 use ws2812_esp32_rmt_driver::driver::color::LedPixelColorGrbw32;
-use ws2812_esp32_rmt_driver::{Ws2812Esp32Rmt, RGBW8};
+use ws2812_esp32_rmt_driver::{LedPixelEsp32Rmt, RGBW8};
 
 fn main() -> ! {
     // Temporary. Will disappear once ESP-IDF 4.4 is released, but for now it is necessary to call this function once,
@@ -10,7 +10,7 @@ fn main() -> ! {
     esp_idf_sys::link_patches();
 
     let led_pin = 26;
-    let mut ws2812 = Ws2812Esp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(0, led_pin).unwrap();
+    let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(0, led_pin).unwrap();
 
     loop {
         let pixels = std::iter::repeat(RGBW8::from((6, 0, 0, White(0)))).take(25);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,6 @@ pub mod lib_smart_leds;
 mod lib_smart_leds;
 
 #[cfg(feature = "smart-leds-trait")]
-pub use lib_smart_leds::{Ws2812Esp32Rmt, RGBW8};
+pub use lib_smart_leds::{LedPixelEsp32Rmt, Ws2812Esp32Rmt, RGBW8};
 #[cfg(feature = "smart-leds-trait")]
 pub use smart_leds_trait::RGB8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 
-#[cfg(feature = "unstable")]
 pub mod driver;
-#[cfg(not(feature = "unstable"))]
-mod driver;
 
 pub use driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
 
@@ -17,6 +14,6 @@ pub mod lib_smart_leds;
 mod lib_smart_leds;
 
 #[cfg(feature = "smart-leds-trait")]
-pub use lib_smart_leds::Ws2812Esp32Rmt;
+pub use lib_smart_leds::{Ws2812Esp32Rmt, RGBW8};
 #[cfg(feature = "smart-leds-trait")]
 pub use smart_leds_trait::RGB8;

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -1,6 +1,8 @@
 //! embedded-graphics draw target API.
 
-use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
+use crate::driver::color::{
+    LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl, LedPixelColorRgbw32,
+};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
 use embedded_graphics_core::draw_target::DrawTarget;
 use embedded_graphics_core::geometry::{OriginDimensions, Point, Size};
@@ -177,7 +179,7 @@ impl<
 
 /// LED pixel shape of `L`-led strip
 pub type LedPixelStrip<const L: usize> = LedPixelMatrix<L, 1>;
-/// WS2812B LED draw target
+/// 24bit GRB LED (Typical RGB LED (WS2812BsSK6812)) draw target
 pub type Ws2812DrawTarget<S> = LedPixelDrawTarget<Rgb888, LedPixelColorGrb24, S>;
 
 #[cfg(test)]

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -2,49 +2,82 @@
 
 use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
-use smart_leds_trait::{SmartLedsWrite, RGB8};
+use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
+use std::marker::PhantomData;
+
+/// 8-bit RGBW (RGB + white)
+pub type RGBW8 = RGBW<u8, u8>;
 
 impl<
-    const N: usize,
-    const R_ORDER: usize,
-    const G_ORDER: usize,
-    const B_ORDER: usize,
-    const W_ORDER: usize,
-> From<RGB8> for LedPixelColorImpl<N, R_ORDER, G_ORDER, B_ORDER, W_ORDER>
+        const N: usize,
+        const R_ORDER: usize,
+        const G_ORDER: usize,
+        const B_ORDER: usize,
+        const W_ORDER: usize,
+    > From<RGB8> for LedPixelColorImpl<N, R_ORDER, G_ORDER, B_ORDER, W_ORDER>
 {
     fn from(x: RGB8) -> Self {
         Self::new_with_rgb(x.r, x.g, x.b)
     }
 }
 
-/// ws2812 driver wrapper providing smart-leds API
-pub struct Ws2812Esp32Rmt {
-    driver: Ws2812Esp32RmtDriver,
+impl<
+        const N: usize,
+        const R_ORDER: usize,
+        const G_ORDER: usize,
+        const B_ORDER: usize,
+        const W_ORDER: usize,
+    > From<RGBW8> for LedPixelColorImpl<N, R_ORDER, G_ORDER, B_ORDER, W_ORDER>
+{
+    fn from(x: RGBW8) -> Self {
+        Self::new_with_rgbw(x.r, x.g, x.b, x.a.0)
+    }
 }
 
-impl Ws2812Esp32Rmt {
+/// ws2812 driver wrapper providing smart-leds API
+pub struct Ws2812Esp32Rmt<CSmart = RGB8, CDev = LedPixelColorGrb24>
+where
+    CDev: LedPixelColor + From<CSmart>,
+{
+    driver: Ws2812Esp32RmtDriver,
+    phantom: PhantomData<(CDev, CSmart)>,
+}
+
+impl<CSmart, CDev> Ws2812Esp32Rmt<CSmart, CDev>
+where
+    CDev: LedPixelColor + From<CSmart>,
+{
     /// Create a new driver wrapper.
     ///
     /// `channel_num` shall be different between different `gpio_num`.
     pub fn new(channel_num: u8, gpio_num: u32) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::new(channel_num, gpio_num)?;
-        Ok(Self { driver })
+        Ok(Self {
+            driver,
+            phantom: Default::default(),
+        })
     }
 }
 
-impl SmartLedsWrite for Ws2812Esp32Rmt {
+impl<CSmart, CDev> SmartLedsWrite for Ws2812Esp32Rmt<CSmart, CDev>
+where
+    CDev: LedPixelColor + From<CSmart>,
+{
     type Error = Ws2812Esp32RmtDriverError;
-    type Color = RGB8;
+    type Color = CSmart;
 
     fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
     where
         T: Iterator<Item = I>,
         I: Into<Self::Color>,
     {
-        let pixel_data: Vec<u8> = iterator
-            .flat_map(|color| LedPixelColorGrb24::from(color.into()).0)
-            .collect();
-        self.driver.write(&pixel_data)
+        let mut pixel_data = Vec::new();
+        for color in iterator {
+            for v in CDev::from(color.into()).as_ref() {
+                pixel_data.push(*v)
+            }
+        }
+        self.driver.write(pixel_data.as_slice())
     }
 }
 

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -34,16 +34,16 @@ impl<
     }
 }
 
-/// ws2812 driver wrapper providing smart-leds API
-pub struct Ws2812Esp32Rmt<CSmart = RGB8, CDev = LedPixelColorGrb24>
+/// ws2812-like smart led driver wrapper providing smart-leds API
+pub struct LedPixelEsp32Rmt<CSmart, CDev>
 where
     CDev: LedPixelColor + From<CSmart>,
 {
     driver: Ws2812Esp32RmtDriver,
-    phantom: PhantomData<(CDev, CSmart)>,
+    phantom: PhantomData<(CSmart, CDev)>,
 }
 
-impl<CSmart, CDev> Ws2812Esp32Rmt<CSmart, CDev>
+impl<CSmart, CDev> LedPixelEsp32Rmt<CSmart, CDev>
 where
     CDev: LedPixelColor + From<CSmart>,
 {
@@ -59,7 +59,7 @@ where
     }
 }
 
-impl<CSmart, CDev> SmartLedsWrite for Ws2812Esp32Rmt<CSmart, CDev>
+impl<CSmart, CDev> SmartLedsWrite for LedPixelEsp32Rmt<CSmart, CDev>
 where
     CDev: LedPixelColor + From<CSmart>,
 {
@@ -80,6 +80,9 @@ where
         self.driver.write(pixel_data.as_slice())
     }
 }
+
+/// ws2812 driver wrapper providing smart-leds API
+pub type Ws2812Esp32Rmt = LedPixelEsp32Rmt<RGB8, LedPixelColorGrb24>;
 
 #[test]
 #[cfg(not(target_vendor = "espressif"))]


### PR DESCRIPTION
Support for four channel smart LED API.

* Stabilize driver module including color.
* Add API to lib_smart_leds
* Add example

Do not introduce four color API to lib_embedded_graphics.rs. Because current embedded-graphics only support 3-color and it is difficult to add RGBW support.

Typical RGBW colors shall be added: `LedPixelColorRgbw32` and `LedPixelColorGrbw32`.
But I have no plans to introduce any other easy-to-use aliases like WS2812. Because there are RGBW and GRBW LED types, both sold under saying "SK6812-RGBW-compatible" products, and users have to check which sequence is correct and choose library parameter.

resolve #5