### PR TITLE
Upgrade the esp-idf-sys dependency to 0.32 and fix code that broke

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1"
 thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-sys = { version = ">=0.30", features = ["binstart"] }
+esp-idf-sys = { version = "0.32", features = ["binstart"] }
 
 [dev-dependencies]
 smart-leds = "0.3"

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -1,7 +1,6 @@
 use esp_idf_sys::*;
 use once_cell::sync::OnceCell;
 use std::cmp::min;
-use std::convert::TryFrom;
 use std::ffi::c_void;
 
 const WS2812_TO0H_NS: u16 = 400;
@@ -48,10 +47,10 @@ impl Ws2812Esp32RmtItemEncoder {
 unsafe extern "C" fn ws2812_rmt_adapter(
     src: *const c_void,
     dest: *mut rmt_item32_t,
-    src_size: u32,
-    wanted_num: u32,
-    translated_size: *mut u32,
-    item_num: *mut u32,
+    src_size: usize,
+    wanted_num: usize,
+    translated_size: *mut usize,
+    item_num: *mut usize,
 ) {
     if src.is_null() || dest.is_null() {
         *translated_size = 0;
@@ -138,7 +137,7 @@ impl Ws2812Esp32RmtDriver {
     /// Panics if the given slice is longer than `u32::MAX`.
     pub fn write(&mut self, pixel_data: &[u8]) -> Result<(), Ws2812Esp32RmtDriverError> {
         let data_ptr = pixel_data.as_ptr();
-        let data_len = u32::try_from(pixel_data.len()).expect("pixel_data.len() > u32::MAX");
+        let data_len = pixel_data.len();
         esp!(unsafe { rmt_write_sample(self.channel, data_ptr, data_len, true) })?;
         Ok(())
     }


### PR DESCRIPTION
The previous version requirement of >=0.30 does not work since esp-idf-sys is allowed to change the public API in 0.31 and later, which they did. Basically changing a bunch of `u32`s into `usize`.

This PR makes the `>=` version requirement into a more strict caret requirement allowing only `0.32.x` where `x` can be anything, but not `0.33` or newer. Since we can expect `esp-idf-sys` to not break semver this should never break our crate here.