### PR TITLE
migrate to esp-idf 5.1 and esp-idf-hal

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,7 +27,7 @@ build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF stable (v4.4)
-ESP_IDF_VERSION = { value = "branch:release/v4.4" }
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF stable (v5.1)
+ESP_IDF_VERSION = { value = "branch:release/v5.1" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master
 #ESP_IDF_VERSION = { value = "master" }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,22 +7,9 @@ target = "xtensa-esp32-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
-
-[target.xtensa-esp32s2-espidf]
-linker = "ldproxy"
-
-[target.xtensa-esp32s3-espidf]
-linker = "ldproxy"
-
-[target.riscv32imc-esp-espidf]
-linker = "ldproxy"
-
-# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
-# See also https://github.com/ivmarkov/embuild/issues/16
-rustflags = ["-C", "default-linker-libraries"]
+rustflags = [ "--cfg",  "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [unstable]
-
 build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,18 +28,12 @@ jobs:
           ws2812-esp32-rmt-driver/target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
-      env:
-        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: cargo build --verbose
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Build example m5atom
-      env:
-        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: cargo build --examples --all-features
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Test
-      env:
-        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: |
         cargo +stable test --target x86_64-unknown-linux-gnu --lib
         cargo +stable test --target x86_64-unknown-linux-gnu --lib --all-features
@@ -48,7 +42,5 @@ jobs:
         cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features --features embedded-graphics-core
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Publish (Dry run)
-      env:
-        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: cargo +stable publish --target x86_64-unknown-linux-gnu --dry-run
       working-directory: ./ws2812-esp32-rmt-driver

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       uses: esp-rs/xtensa-toolchain@v1.5
       with:
         default: true
-        version: "1.70.0"
+        version: "1.74.0"
         ldproxy: true
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,12 +28,18 @@ jobs:
           ws2812-esp32-rmt-driver/target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
+      env:
+        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: cargo build --verbose
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Build example m5atom
+      env:
+        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: cargo build --examples --all-features
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Test
+      env:
+        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: |
         cargo +stable test --target x86_64-unknown-linux-gnu --lib
         cargo +stable test --target x86_64-unknown-linux-gnu --lib --all-features
@@ -42,5 +48,7 @@ jobs:
         cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features --features embedded-graphics-core
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Publish (Dry run)
+      env:
+        RUSTFLAGS: "${{ '--cfg espidf_time64' }}"
       run: cargo +stable publish --target x86_64-unknown-linux-gnu --dry-run
       working-directory: ./ws2812-esp32-rmt-driver

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ unstable = []
 [dependencies]
 smart-leds-trait = { version = "0.2", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
-once_cell = "1"
 thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ once_cell = "1"
 thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-sys = { version = ">=0.32", features = ["binstart"] }
+esp-idf-sys = { version = ">=0.33", features = ["binstart"] }
+esp-idf-hal = ">=0.42"
 
 [dev-dependencies]
 smart-leds = "0.3"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ specify version explicitly in your project.
 ```toml
 [dependencies]
 esp-idf-sys = { version = "*", features = ["binstart"] }
+esp-idf-hal = "*"
 smart-leds = "*"
 
 ws2812-esp32-rmt-driver = "*"
@@ -54,8 +55,6 @@ $ cargo espflash
   API `ws2812_esp32_rmt_driver::lib_embedded_graphics`.
 * `features = ["smart-leds"]` or default to enable minimum smart-leds API.
 * `features = ["smart-leds", "unstable"]` to enable detailed smart-leds API `ws2812_esp32_rmt_driver::lib_smart_leds`.
-
-
 
 ## Development
 

--- a/examples/m5atom_embedded_graphics.rs
+++ b/examples/m5atom_embedded_graphics.rs
@@ -2,6 +2,7 @@
 use embedded_graphics::pixelcolor::Rgb888;
 use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, PrimitiveStyle, Rectangle, Triangle};
+use esp_idf_hal::peripherals::Peripherals;
 use std::thread::sleep;
 use std::time::Duration;
 use ws2812_esp32_rmt_driver::lib_embedded_graphics::{LedPixelMatrix, Ws2812DrawTarget};
@@ -11,7 +12,11 @@ fn main() -> ! {
     // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
     esp_idf_sys::link_patches();
 
-    let mut draw = Ws2812DrawTarget::<LedPixelMatrix<5, 5>>::new(0, 27).unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let led_pin = peripherals.pins.gpio27;
+    let channel = peripherals.rmt.channel0;
+
+    let mut draw = Ws2812DrawTarget::<LedPixelMatrix<5, 5>>::new(channel, led_pin).unwrap();
     draw.set_brightness(40);
 
     println!("Start Ws2812DrawTarget!");

--- a/examples/m5atom_smart_leds.rs
+++ b/examples/m5atom_smart_leds.rs
@@ -1,3 +1,4 @@
+use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_sys::*;
 use smart_leds::hsv::{hsv2rgb, Hsv};
 use smart_leds_trait::SmartLedsWrite;
@@ -10,7 +11,10 @@ fn main() -> ! {
     // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
     esp_idf_sys::link_patches();
 
-    let mut ws2812 = Ws2812Esp32Rmt::new(0, 27).unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let led_pin = peripherals.pins.gpio27;
+    let channel = peripherals.rmt.channel0;
+    let mut ws2812 = Ws2812Esp32Rmt::new(channel, led_pin).unwrap();
 
     println!("Start NeoPixel rainbow!");
 

--- a/examples/smart_leds_sk6812_rgbw.rs
+++ b/examples/smart_leds_sk6812_rgbw.rs
@@ -1,3 +1,4 @@
+use esp_idf_hal::peripherals::Peripherals;
 use smart_leds_trait::{SmartLedsWrite, White};
 use std::thread::sleep;
 use std::time::Duration;
@@ -9,8 +10,10 @@ fn main() -> ! {
     // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
     esp_idf_sys::link_patches();
 
-    let led_pin = 26;
-    let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(0, led_pin).unwrap();
+    let peripherals = Peripherals::take().unwrap();
+    let led_pin = peripherals.pins.gpio26;
+    let channel = peripherals.rmt.channel0;
+    let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(channel, led_pin).unwrap();
 
     loop {
         let pixels = std::iter::repeat(RGBW8::from((6, 0, 0, White(0)))).take(25);

--- a/src/driver/color.rs
+++ b/src/driver/color.rs
@@ -2,7 +2,7 @@
 
 /// LED pixel color trait
 pub trait LedPixelColor:
-    Ord + PartialOrd + Eq + PartialEq + Clone + AsRef<[u8]> + AsMut<[u8]>
+    Ord + PartialOrd + Eq + PartialEq + Clone + Sync + AsRef<[u8]> + AsMut<[u8]>
 {
     /// byte per pixel. e.g. 3 for typical RGB.
     const BPP: usize;

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -116,7 +116,7 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         Ok(Self { tx, encoder })
     }
 
-    /// Writes pixel data from a pixel-byte-pointer sequence to the IO pin.
+    /// Writes pixel data from a pixel-byte sequence to the IO pin.
     ///
     /// Byte count per LED pixel and channel order is not handled by this method.
     /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
@@ -130,34 +130,7 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// Iteration of `pixel_sequence` happens inside an interrupt handler so beware of side-effects
     /// that don't work in interrupt handlers.
     /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter_blocking()] for details.
-    pub fn write_ptr_iter_blocking<'a, 'b, T>(
-        &'a mut self,
-        pixel_sequence: T,
-    ) -> Result<(), Ws2812Esp32RmtDriverError>
-    where
-        'b: 'a,
-        T: Iterator<Item = &'b u8> + Send + 'b,
-    {
-        let signal = self.encoder.encode_iter(pixel_sequence.cloned());
-        self.tx.start_iter_blocking(signal)?;
-        Ok(())
-    }
-
-    /// Writes pixel data from a pixel-byte-value sequence to the IO pin.
-    ///
-    /// Byte count per LED pixel and channel order is not handled by this method.
-    /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if an RMT driver error occurred.
-    ///
-    /// # Warning
-    ///
-    /// Iteration of `pixel_sequence` happens inside an interrupt handler so beware of side-effects
-    /// that don't work in interrupt handlers.
-    /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter_blocking()] for details.
-    pub fn write_val_iter_blocking<'a, 'b, T>(
+    pub fn write_blocking<'a, 'b, T>(
         &'a mut self,
         pixel_sequence: T,
     ) -> Result<(), Ws2812Esp32RmtDriverError>
@@ -170,12 +143,12 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         Ok(())
     }
 
-    /// Writes pixel data from a pixel-byte-pointer sequence to the IO pin.
+    /// Writes pixel data from a pixel-byte sequence to the IO pin.
     ///
     /// Byte count per LED pixel and channel order is not handled by this method.
     /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
     ///
-    /// Note that this requires `pixel_sequence` to be [`Box`]ed for an allocation free version see [`Self::write_iter_blocking`].
+    /// Note that this requires `pixel_sequence` to be [`Box`]ed for an allocation free version see [`Self::write_blocking`].
     ///
     /// # Errors
     ///
@@ -187,36 +160,7 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// that don't work in interrupt handlers.
     /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter()] for details.
     #[cfg(feature = "unstable")]
-    pub fn write_ptr_iter<'b, T>(
-        &'static mut self,
-        pixel_sequence: T,
-    ) -> Result<(), Ws2812Esp32RmtDriverError>
-    where
-        T: Iterator<Item = &'b u8> + Send + 'static,
-    {
-        let signal = self.encoder.encode_iter(pixel_sequence.cloned());
-        self.tx.start_iter(signal)?;
-        Ok(())
-    }
-
-    /// Writes pixel data from a pixel-byte-value sequence to the IO pin.
-    ///
-    /// Byte count per LED pixel and channel order is not handled by this method.
-    /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
-    ///
-    /// Note that this requires `pixel_sequence` to be [`Box`]ed for an allocation free version see [`Self::write_iter_blocking`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if an RMT driver error occurred.
-    ///
-    /// # Warning
-    ///
-    /// Iteration of `pixel_sequence` happens inside an interrupt handler so beware of side-effects
-    /// that don't work in interrupt handlers.
-    /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter()] for details.
-    #[cfg(feature = "unstable")]
-    pub fn write_val_iter<'b, T>(
+    pub fn write<'b, T>(
         &'static mut self,
         pixel_sequence: T,
     ) -> Result<(), Ws2812Esp32RmtDriverError>

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -63,6 +63,7 @@ impl Ws2812Esp32RmtItemEncoder {
     /// # Returns
     ///
     /// An iterator over the RMT items that represent the encoded data.
+    #[inline]
     fn encode_iter_blocking<'a, 'b, T>(
         &'a self,
         src: T,

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -1,73 +1,57 @@
-use esp_idf_sys::*;
+use esp_idf_hal::gpio::OutputPin;
+use esp_idf_hal::peripheral::Peripheral;
+use esp_idf_hal::rmt::config::TransmitConfig;
+use esp_idf_hal::rmt::{PinState, Pulse, RmtChannel, TxRmtDriver, VariableLengthSignal};
+use esp_idf_hal::units::Hertz;
+use esp_idf_sys::EspError;
 use once_cell::sync::OnceCell;
-use std::cmp::min;
-use std::ffi::c_void;
-
-const WS2812_TO0H_NS: u16 = 400;
-const WS2812_TO0L_NS: u16 = 850;
-const WS2812_TO1H_NS: u16 = 800;
-const WS2812_TO1L_NS: u16 = 450;
+use std::time::Duration;
 
 static WS2812_ITEM_ENCODER: OnceCell<Ws2812Esp32RmtItemEncoder> = OnceCell::new();
+const WS2812_TO0H_NS: Duration = Duration::from_nanos(400);
+const WS2812_TO0L_NS: Duration = Duration::from_nanos(850);
+const WS2812_TO1H_NS: Duration = Duration::from_nanos(800);
+const WS2812_TO1L_NS: Duration = Duration::from_nanos(450);
 
 #[repr(C)]
 struct Ws2812Esp32RmtItemEncoder {
-    bit0: u32,
-    bit1: u32,
+    bit0: (Pulse, Pulse),
+    bit1: (Pulse, Pulse),
 }
 
 impl Ws2812Esp32RmtItemEncoder {
-    fn new(channel: rmt_channel_t) -> Result<Self, EspError> {
-        let mut clock_hz = 0u32;
-        esp!(unsafe { rmt_get_counter_clock(channel, &mut clock_hz as *mut u32) })?;
-        let clock_hz = clock_hz as u64;
-        let to0h_clk = ((WS2812_TO0H_NS as u64) * clock_hz / 1_000_000_000) as u32;
-        let to0l_clk = ((WS2812_TO0L_NS as u64) * clock_hz / 1_000_000_000) as u32;
-        let to1h_clk = ((WS2812_TO1H_NS as u64) * clock_hz / 1_000_000_000) as u32;
-        let to1l_clk = ((WS2812_TO1L_NS as u64) * clock_hz / 1_000_000_000) as u32;
-        let bit0 = to0h_clk | (1 << 15) | (to0l_clk << 16);
-        let bit1 = to1h_clk | (1 << 15) | (to1l_clk << 16);
-        Ok(Self { bit0, bit1 })
+    fn new(clock_hz: Hertz) -> Result<Self, EspError> {
+        let (t0h, t0l, t1h, t1l) = (
+            Pulse::new_with_duration(clock_hz, PinState::High, &WS2812_TO0H_NS)?,
+            Pulse::new_with_duration(clock_hz, PinState::Low, &WS2812_TO0L_NS)?,
+            Pulse::new_with_duration(clock_hz, PinState::High, &WS2812_TO1H_NS)?,
+            Pulse::new_with_duration(clock_hz, PinState::Low, &WS2812_TO1L_NS)?,
+        );
+        Ok(Self {
+            bit0: (t0h, t0l),
+            bit1: (t1h, t1l),
+        })
     }
 
-    fn encode(&self, src_slice: &[u8], dest_slice: &mut [rmt_item32_t]) {
-        for (k, &v) in src_slice.iter().enumerate() {
+    fn encode_variable<T>(&self, src: T) -> Result<VariableLengthSignal, EspError>
+    where
+        T: Iterator<Item = u8>,
+    {
+        let mut s = VariableLengthSignal::new();
+
+        for v in src {
             for i in 0..(u8::BITS as usize) {
-                dest_slice[k * (u8::BITS as usize) + i].__bindgen_anon_1.val =
-                    if v & (1 << (7 - i)) != 0 {
-                        self.bit1
-                    } else {
-                        self.bit0
-                    };
+                let bit_sig = if v & (1 << (7 - i)) != 0 {
+                    self.bit1
+                } else {
+                    self.bit0
+                };
+                s.push([bit_sig.0, bit_sig.1].iter())?;
             }
         }
+
+        Ok(s)
     }
-}
-
-unsafe extern "C" fn ws2812_rmt_adapter(
-    src: *const c_void,
-    dest: *mut rmt_item32_t,
-    src_size: usize,
-    wanted_num: usize,
-    translated_size: *mut usize,
-    item_num: *mut usize,
-) {
-    if src.is_null() || dest.is_null() {
-        *translated_size = 0;
-        *item_num = 0;
-        return;
-    }
-
-    let src_len = min(src_size, wanted_num / 8);
-    let src_slice = std::slice::from_raw_parts(src as *const u8, src_len);
-    let dest_slice = std::slice::from_raw_parts_mut(dest, src_slice.len() * 8);
-
-    if let Some(encoder) = WS2812_ITEM_ENCODER.get() {
-        encoder.encode(src_slice, dest_slice)
-    }
-
-    *translated_size = src_slice.len() as _;
-    *item_num = dest_slice.len() as _;
 }
 
 /// WS2812 ESP32 RMT Driver error.
@@ -75,52 +59,34 @@ unsafe extern "C" fn ws2812_rmt_adapter(
 #[error(transparent)]
 pub struct Ws2812Esp32RmtDriverError(#[from] EspError);
 
-/// Low-level WS2812 ESP32 RMT driver.
-pub struct Ws2812Esp32RmtDriver {
-    /// The RMT channel ID.
-    channel: rmt_channel_t,
+/// WS2812 ESP32 RMT driver wrapper.
+pub struct Ws2812Esp32RmtDriver<'d> {
+    /// TxRMT driver.
+    tx: TxRmtDriver<'d>,
 }
 
-impl Ws2812Esp32RmtDriver {
-    /// Creates a Low-level WS2812 ESP32 RMT driver.
+impl<'d> Ws2812Esp32RmtDriver<'d> {
+    /// Creates a WS2812 ESP32 RMT driver wrapper.
     ///
-    /// RMT driver of `channel_num` shall be initialized and installed for `gpio_num`.
-    /// `channel_num` shall be different between different `gpio_num`.
+    /// RMT driver of `channel` shall be initialized and installed for `pin`.
+    /// `channel` shall be different between different `pin`.
     ///
     /// # Errors
     ///
     /// Returns an error if the RMT driver initialization failed.
-    pub fn new(channel_num: u8, gpio_num: u32) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let channel = channel_num as rmt_channel_t;
-        let gpio_num = gpio_num as gpio_num_t;
-        let clk_div = 2;
+    pub fn new<C: RmtChannel>(
+        channel: impl Peripheral<P = C> + 'd,
+        pin: impl Peripheral<P = impl OutputPin> + 'd,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let config = TransmitConfig::new().clock_divider(1);
+        let tx = TxRmtDriver::new(channel, pin, &config)?;
 
-        let rmt_cfg = rmt_config_t {
-            rmt_mode: rmt_mode_t_RMT_MODE_TX,
-            channel,
-            gpio_num,
-            clk_div,
-            mem_block_num: 1,
-            __bindgen_anon_1: rmt_config_t__bindgen_ty_1 {
-                tx_config: rmt_tx_config_t {
-                    loop_en: false,
-                    carrier_level: rmt_carrier_level_t_RMT_CARRIER_LEVEL_HIGH,
-                    carrier_en: false,
-                    idle_level: rmt_idle_level_t_RMT_IDLE_LEVEL_LOW,
-                    idle_output_en: true,
-                    ..Default::default()
-                },
-            },
-            ..Default::default()
-        };
-        esp!(unsafe { rmt_config(&rmt_cfg) })?;
-        esp!(unsafe { rmt_driver_install(channel, 0, 0) })?;
-        esp!(unsafe { rmt_translator_init(channel, Some(ws2812_rmt_adapter)) })?;
+        let _encoder = WS2812_ITEM_ENCODER.get_or_try_init(|| {
+            let clock_hz = tx.counter_clock()?;
+            Ws2812Esp32RmtItemEncoder::new(clock_hz)
+        })?;
 
-        let _encoder =
-            WS2812_ITEM_ENCODER.get_or_try_init(|| Ws2812Esp32RmtItemEncoder::new(channel))?;
-
-        Ok(Self { channel })
+        Ok(Self { tx })
     }
 
     /// Writes pixel data from the slice to the IO pin.
@@ -131,20 +97,11 @@ impl Ws2812Esp32RmtDriver {
     /// # Errors
     ///
     /// Returns an error if an RMT driver error occurred.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given slice is longer than `u32::MAX`.
     pub fn write(&mut self, pixel_data: &[u8]) -> Result<(), Ws2812Esp32RmtDriverError> {
-        let data_ptr = pixel_data.as_ptr();
-        esp!(unsafe { rmt_write_sample(self.channel, data_ptr, pixel_data.len(), true) })?;
+        if let Some(encoder) = WS2812_ITEM_ENCODER.get() {
+            let signal = encoder.encode_variable(pixel_data.iter().cloned())?;
+            self.tx.start_blocking(&signal)?;
+        }
         Ok(())
-    }
-}
-
-impl Drop for Ws2812Esp32RmtDriver {
-    /// Uninstalls RMT driver
-    fn drop(&mut self) {
-        esp!(unsafe { rmt_driver_uninstall(self.channel) }).unwrap()
     }
 }

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -26,9 +26,16 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         })
     }
 
-    /// Writes GRB pixel binary slice.
-    pub fn write(&mut self, pixel_data: &[u8]) -> Result<(), Ws2812Esp32RmtDriverError> {
-        self.pixel_data = Some(pixel_data.to_vec());
+    /// Writes GRB pixel binary iterator.
+    pub fn write_iter_blocking<'a, 'b, T>(
+        &'a mut self,
+        pixel_sequence: T,
+    ) -> Result<(), Ws2812Esp32RmtDriverError>
+    where
+        'b: 'a,
+        T: Iterator<Item = &'b u8> + Send + 'b,
+    {
+        self.pixel_data = Some(pixel_sequence.cloned().collect());
         Ok(())
     }
 }
@@ -39,6 +46,6 @@ fn test_ws2812_esp32_rmt_driver_mock() {
 
     let mut driver = Ws2812Esp32RmtDriver::new().unwrap();
     assert_eq!(driver.pixel_data, None);
-    driver.write(&sample_data).unwrap();
+    driver.write_iter_blocking(sample_data.iter()).unwrap();
     assert_eq!(driver.pixel_data.unwrap(), &sample_data);
 }

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -26,21 +26,8 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         })
     }
 
-    /// Writes a pixel-byte-pointer sequence.
-    pub fn write_ptr_iter_blocking<'a, 'b, T>(
-        &'a mut self,
-        pixel_sequence: T,
-    ) -> Result<(), Ws2812Esp32RmtDriverError>
-    where
-        'b: 'a,
-        T: Iterator<Item = &'b u8> + Send + 'b,
-    {
-        self.pixel_data = Some(pixel_sequence.cloned().collect());
-        Ok(())
-    }
-
-    /// Writes a pixel-byte-value sequence.
-    pub fn write_val_iter_blocking<'a, 'b, T>(
+    /// Writes a pixel-byte sequence.
+    pub fn write_blocking<'a, 'b, T>(
         &'a mut self,
         pixel_sequence: T,
     ) -> Result<(), Ws2812Esp32RmtDriverError>
@@ -52,23 +39,9 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         Ok(())
     }
 
-    /// Writes a pixel-byte-pointer sequence.
+    /// Writes a pixel-byte sequence.
     #[cfg(feature = "unstable")]
-    pub fn write_ptr_iter<'a, 'b, T>(
-        &'a mut self,
-        pixel_sequence: T,
-    ) -> Result<(), Ws2812Esp32RmtDriverError>
-    where
-        'b: 'a,
-        T: Iterator<Item = &'b u8> + Send + 'b,
-    {
-        self.pixel_data = Some(pixel_sequence.cloned().collect());
-        Ok(())
-    }
-
-    /// Writes a pixel-byte-value sequence.
-    #[cfg(feature = "unstable")]
-    pub fn write_val_iter<'a, 'b, T>(
+    pub fn write<'a, 'b, T>(
         &'a mut self,
         pixel_sequence: T,
     ) -> Result<(), Ws2812Esp32RmtDriverError>
@@ -87,12 +60,6 @@ fn test_ws2812_esp32_rmt_driver_mock() {
 
     let mut driver = Ws2812Esp32RmtDriver::new().unwrap();
     assert_eq!(driver.pixel_data, None);
-    driver.write_ptr_iter_blocking(sample_data.iter()).unwrap();
-    assert_eq!(driver.pixel_data.unwrap(), &sample_data);
-
-    driver.pixel_data = None;
-    driver
-        .write_val_iter_blocking(sample_data.iter().cloned())
-        .unwrap();
+    driver.write_blocking(sample_data.iter().cloned()).unwrap();
     assert_eq!(driver.pixel_data.unwrap(), &sample_data);
 }

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 /// WS2812 ESP32 RMT Driver error.
 #[derive(thiserror::Error, Debug)]
 #[error("mock Ws2812Esp32RmtDriverError")]
@@ -7,16 +9,21 @@ pub struct Ws2812Esp32RmtDriverError;
 ///
 /// If the target vendor does not equals to "espressif", this mock is used instead of genuine
 /// Low-level WS2812 ESP32 RMT driver.
-pub struct Ws2812Esp32RmtDriver {
+pub struct Ws2812Esp32RmtDriver<'d> {
     /// Pixel binary array to be written
     pub pixel_data: Option<Vec<u8>>,
+
+    /// Dummy phantom to take care of lifetime
+    phantom: PhantomData<&'d Option<Vec<u8>>>,
 }
 
-impl Ws2812Esp32RmtDriver {
+impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// Creates a mock of `Ws2812Esp32RmtDriver`.
-    /// All arguments shall be ignored and always returns `Ok(_)`.
-    pub fn new(_channel_num: u8, _gpio_num: u32) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        Ok(Self { pixel_data: None })
+    pub fn new() -> Result<Self, Ws2812Esp32RmtDriverError> {
+        Ok(Self {
+            pixel_data: None,
+            phantom: Default::default(),
+        })
     }
 
     /// Writes GRB pixel binary slice.
@@ -30,7 +37,7 @@ impl Ws2812Esp32RmtDriver {
 fn test_ws2812_esp32_rmt_driver_mock() {
     let sample_data: [u8; 6] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
 
-    let mut driver = Ws2812Esp32RmtDriver::new(0, 27).unwrap();
+    let mut driver = Ws2812Esp32RmtDriver::new().unwrap();
     assert_eq!(driver.pixel_data, None);
     driver.write(&sample_data).unwrap();
     assert_eq!(driver.pixel_data.unwrap(), &sample_data);

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -130,7 +130,7 @@ where
     /// Write changes from a framebuffer to the LED pixels
     pub fn flush(&mut self) -> Result<(), Ws2812Esp32RmtDriverError> {
         if self.changed {
-            self.driver.write_ptr_iter_blocking(self.data.iter())?;
+            self.driver.write_blocking(self.data.iter().copied())?;
             self.changed = false;
         }
         Ok(())

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -1,13 +1,14 @@
 //! embedded-graphics draw target API.
 
-use crate::driver::color::{
-    LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl, LedPixelColorRgbw32,
-};
+use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
 use embedded_graphics_core::draw_target::DrawTarget;
 use embedded_graphics_core::geometry::{OriginDimensions, Point, Size};
 use embedded_graphics_core::pixelcolor::{Rgb888, RgbColor};
 use embedded_graphics_core::Pixel;
+use esp_idf_hal::gpio::OutputPin;
+use esp_idf_hal::peripheral::Peripheral;
+use esp_idf_hal::rmt::RmtChannel;
 use std::marker::PhantomData;
 
 /// LED pixel shape
@@ -48,20 +49,20 @@ impl<const W: usize, const H: usize> LedPixelShape for LedPixelMatrix<W, H> {
 /// * `S` - the LED pixel shape
 ///
 /// `flush()` operation shall be required to write changes from a framebuffer to the display.
-pub struct LedPixelDrawTarget<CDraw, CDev, S>
+pub struct LedPixelDrawTarget<'d, CDraw, CDev, S>
 where
     CDraw: RgbColor,
     CDev: LedPixelColor + From<CDraw>,
     S: LedPixelShape,
 {
-    driver: Ws2812Esp32RmtDriver,
+    driver: Ws2812Esp32RmtDriver<'d>,
     data: Vec<u8>,
     brightness: u8,
     changed: bool,
     _phantom: PhantomData<(CDraw, CDev, S)>,
 }
 
-impl<CDraw, CDev, S> LedPixelDrawTarget<CDraw, CDev, S>
+impl<'d, CDraw, CDev, S> LedPixelDrawTarget<'d, CDraw, CDev, S>
 where
     CDraw: RgbColor,
     CDev: LedPixelColor + From<CDraw>,
@@ -69,9 +70,12 @@ where
 {
     /// Create a new draw target.
     ///
-    /// `channel_num` shall be different between different `gpio_num`.
-    pub fn new(channel_num: u8, gpio_num: u32) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let driver = Ws2812Esp32RmtDriver::new(channel_num, gpio_num)?;
+    /// `channel` shall be different between different `pin`.
+    pub fn new<C: RmtChannel>(
+        channel: impl Peripheral<P = C> + 'd,
+        pin: impl Peripheral<P = impl OutputPin> + 'd,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
         let data = std::iter::repeat(0)
             .take(S::pixel_len() * CDev::BPP)
             .collect::<Vec<_>>();
@@ -116,7 +120,7 @@ where
     }
 }
 
-impl<CDraw, CDev, S> OriginDimensions for LedPixelDrawTarget<CDraw, CDev, S>
+impl<'d, CDraw, CDev, S> OriginDimensions for LedPixelDrawTarget<'d, CDraw, CDev, S>
 where
     CDraw: RgbColor,
     CDev: LedPixelColor + From<CDraw>,
@@ -128,7 +132,7 @@ where
     }
 }
 
-impl<CDraw, CDev, S> DrawTarget for LedPixelDrawTarget<CDraw, CDev, S>
+impl<'d, CDraw, CDev, S> DrawTarget for LedPixelDrawTarget<'d, CDraw, CDev, S>
 where
     CDraw: RgbColor,
     CDev: LedPixelColor + From<CDraw>,
@@ -180,7 +184,7 @@ impl<
 /// LED pixel shape of `L`-led strip
 pub type LedPixelStrip<const L: usize> = LedPixelMatrix<L, 1>;
 /// 24bit GRB LED (Typical RGB LED (WS2812BsSK6812)) draw target
-pub type Ws2812DrawTarget<S> = LedPixelDrawTarget<Rgb888, LedPixelColorGrb24, S>;
+pub type Ws2812DrawTarget<'d, S> = LedPixelDrawTarget<'d, Rgb888, LedPixelColorGrb24, S>;
 
 #[cfg(test)]
 mod test {

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -130,7 +130,7 @@ where
     /// Write changes from a framebuffer to the LED pixels
     pub fn flush(&mut self) -> Result<(), Ws2812Esp32RmtDriverError> {
         if self.changed {
-            self.driver.write_iter_blocking(self.data.iter())?;
+            self.driver.write_ptr_iter_blocking(self.data.iter())?;
             self.changed = false;
         }
         Ok(())

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -130,7 +130,7 @@ where
     /// Write changes from a framebuffer to the LED pixels
     pub fn flush(&mut self) -> Result<(), Ws2812Esp32RmtDriverError> {
         if self.changed {
-            self.driver.write(&self.data)?;
+            self.driver.write_iter_blocking(self.data.iter())?;
             self.changed = false;
         }
         Ok(())

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -98,12 +98,10 @@ where
         T: Iterator<Item = I> + Send,
         I: Into<CSmart>,
     {
-        self.driver
-            .write_val_iter_blocking(iterator.flat_map(|color| {
-                let c =
-                    LedPixelColorImpl::<N, R_ORDER, G_ORDER, B_ORDER, W_ORDER>::from(color.into());
-                c.0
-            }))?;
+        self.driver.write_blocking(iterator.flat_map(|color| {
+            let c = LedPixelColorImpl::<N, R_ORDER, G_ORDER, B_ORDER, W_ORDER>::from(color.into());
+            c.0
+        }))?;
         Ok(())
     }
 }
@@ -129,7 +127,7 @@ where
             vec.extend_from_slice(CDev::from(color.into()).as_ref());
             vec
         });
-        self.driver.write_ptr_iter_blocking(pixel_data.iter())?;
+        self.driver.write_blocking(pixel_data.into_iter())?;
         Ok(())
     }
 }

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -88,13 +88,12 @@ where
         T: Iterator<Item = I>,
         I: Into<Self::Color>,
     {
-        let mut pixel_data = Vec::new();
-        for color in iterator {
-            for v in CDev::from(color.into()).as_ref() {
-                pixel_data.push(*v)
-            }
-        }
-        self.driver.write(pixel_data.as_slice())
+        let pixel_data = iterator.fold(Vec::new(), |mut vec, color| {
+            vec.extend_from_slice(CDev::from(color.into()).as_ref());
+            vec
+        });
+        self.driver.write_iter_blocking(pixel_data.iter())?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR is to migrate to esp-idf 5 and use the safe `Peripherals` abstraction.
It also introduce zero-copy API to smartled interface (#30 ).

fix #31 and resolve #30