### PR TITLE
Remove all default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/cat-in-136/ws2812-esp32-rmt-smart-leds"
 edition = "2021"
 
 [features]
-default = ["smart-leds-trait", "embedded-graphics-core"]
 unstable = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ cargo espflash
 
 * `features = ["embedded-graphics-core", "unstable"]` to enable embedded-graphics
   API `ws2812_esp32_rmt_driver::lib_embedded_graphics`.
-* `features = ["smart-leds"]` or default to enable minimum smart-leds API.
+* `features = ["smart-leds"]` to enable minimum smart-leds API.
 * `features = ["smart-leds", "unstable"]` to enable detailed smart-leds API `ws2812_esp32_rmt_driver::lib_smart_leds`.
 
 ## Development


### PR DESCRIPTION
I know you juuuust published a breaking change. So this request is a bit too late. But I guess there might be a `0.8.0` release at some point in the future. That means you might not want to merge this just now. Unless you really agree with my argument here and go ahead with `0.8.0` very soon.

Would you consider making all features opt-in instead of on by default? There are people (including me) considering "default features" to be a design mistake in Cargo. They make it too easy to pull in stuff you don't need. Worst is when I directly depend on crate `foo` and I *really want* its feature `some-feature` to be disabled. But a transitive dependency also pulls in `foo` and they have not set `default-features = false` and involuntarily pull in `some-feature` in my dependency tree even though that transitive dependency is not even using it!
