### PR TITLE
Use standard Result type instead of anyhow since it's not needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ embedded-graphics = "0.8"
 
 [build-dependencies]
 embuild = "0.31"
-anyhow = "1"
 
 [profile.release]
 strip = true

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,8 @@
 // Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     if std::env::var("CARGO_CFG_TARGET_VENDOR") == Ok("espressif".to_string()) {
         embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
-        embuild::build::LinkArgs::output_propagated("ESP_IDF")
-    } else {
-        Ok(())
+        embuild::build::LinkArgs::output_propagated("ESP_IDF")?
     }
+    Ok(())
 }


### PR DESCRIPTION
Anyhow is pulled in here for very little gain, just costs an extra build time dependency. I did the same towards the esp32 template a while back and that was accepted there: https://github.com/esp-rs/esp-idf-template/pull/73