### PR TITLE
Add easier support for riscv based ESP32

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,11 @@ target = "xtensa-esp32-espidf"
 linker = "ldproxy"
 rustflags = [ "--cfg",  "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+runner = "espflash flash --monitor"
+rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+
 [unstable]
 build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]


### PR DESCRIPTION
I never develop towards the Xtensa based chips, only the `C`-series riscv boards. So I don't have the custom rustc fork with Xtensa support (the riscv support is built into mainline). Merging this makes it way easier for me to build the examples, as I can just append `--target riscv32imc-esp-espidf` to my build command and have it work.