### PR TITLE
fix build failure due to breaking change in embedded-hal-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-sys = { version = ">=0.33", features = ["binstart"] }
-esp-idf-hal = ">=0.42"
+esp-idf-hal = "0.42"
 
 [dev-dependencies]
 smart-leds = "0.3"


### PR DESCRIPTION
Build failed due to the embedded-hal-async breaking change that rustc 1.74.0-nightly is required to build it. To resolve this issue, make the dependency version of esp-idf-hal from ">= 0.42" to "0.42". 

```
error: package `embedded-hal-async v1.0.0` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.74.0-nightly
Either upgrade to rustc 1.75 or newer, or use
cargo update embedded-hal-async@1.0.0 --precise ver
where `ver` is the latest version of `embedded-hal-async` supporting rustc 1.74.0-nightly
```