### PR TITLE
chore(deps): update esp-idf-hal from 0.42 to 0.43.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-sys = { version = ">=0.33", features = ["binstart"] }
-esp-idf-hal = ">=0.43"
+esp-idf-hal = ">=0.43.1"
 
 [dev-dependencies]
 smart-leds = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-sys = { version = ">=0.33", features = ["binstart"] }
-esp-idf-hal = "0.42"
+esp-idf-hal = ">=0.43"
 
 [dev-dependencies]
 smart-leds = "0.3"


### PR DESCRIPTION
This PR is to update esp-idf-hal to ~~0.43~~ 0.43.1

Edit : Just noticed the breaking changes of esp-idf hal happens on [0.43.1](https://github.com/esp-rs/esp-idf-hal/blob/04ad4299a895761d2866dc26859fbde3692ab103/src/rmt.rs#L662) not on 0.43 