### PR TITLE
Update for newer HAL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-sys = { version = ">=0.33", features = ["binstart"] }
-esp-idf-hal = "0.42"
+esp-idf-hal = ">=0.43.2"
 
 [dev-dependencies]
 smart-leds = "0.3"


### PR DESCRIPTION
This change depends on https://github.com/esp-rs/esp-idf-hal/pull/386 getting merged and a new version getting tagged.
Alternatively, we can store `t0h, t0l, t1h, t1l` and create a new `Symbol` for each bit in the iterator; I'm not sure if `Copy` will be faster than creating the `Symbol`

Closes #42 