### PR TITLE
Update esp-idf-hal with workaround to copy symbol

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       uses: esp-rs/xtensa-toolchain@v1.5
       with:
         default: true
-        version: "1.74.0"
+        version: "1.75.0"
         ldproxy: true
     - uses: actions/checkout@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ embedded-graphics-core = { version = "0.4", optional = true }
 thiserror = "1"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-sys = { version = ">=0.33", features = ["binstart"] }
-esp-idf-hal = "0.42"
+esp-idf-sys = { version = "0.34", features = ["binstart"] }
+esp-idf-hal = "0.43"
 
 [dev-dependencies]
 smart-leds = "0.3"


### PR DESCRIPTION
Similar to #43 this updates esp-idf-hal and also esp-idf-sys to the most recent version.
Because the change in esp-idf-hal that makes Symbol copy is not yet published, this uses unsafe code as a workaround.
The unsafe code just copies the bytes, so this should make no difference to Symbol being cloned/copy.
Once a new esp-idf-hal version is out, the unsafe part can just be replaced by self.bit0 and self.bit1 again.