### PR TITLE
Introduce no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,18 +28,21 @@ jobs:
           ws2812-esp32-rmt-driver/target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
-      run: cargo build --verbose
+      run: |
+        cargo build
+        cargo build --all-features
+        cargo build --no-default-features --features=alloc
+        cargo build --no-default-features --features=alloc,smart-leds-trait,embedded-graphics-core
       working-directory: ./ws2812-esp32-rmt-driver
-    - name: Build example m5atom
+    - name: Build examples
       run: cargo build --examples --all-features
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Test
       run: |
         cargo +stable test --target x86_64-unknown-linux-gnu --lib
         cargo +stable test --target x86_64-unknown-linux-gnu --lib --all-features
-        cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features
-        cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features --features smart-leds-trait
-        cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features --features embedded-graphics-core
+        cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features --features std,smart-leds-trait
+        cargo +stable test --target x86_64-unknown-linux-gnu --lib --no-default-features --features std,embedded-graphics-core
       working-directory: ./ws2812-esp32-rmt-driver
     - name: Publish (Dry run)
       run: cargo +stable publish --target x86_64-unknown-linux-gnu --dry-run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 [dependencies]
 smart-leds-trait = { version = "0.3", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
+heapless = "0.8"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-hal = { version = "0.44", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 smart-leds-trait = { version = "0.3", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
-thiserror = "1"
+snafu = "0.8"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-sys = { version = "0.35", features = ["binstart"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,18 @@ readme = "README.md"
 repository = "https://github.com/cat-in-136/ws2812-esp32-rmt-smart-leds"
 edition = "2021"
 
-[features]
-default = ["std"]
-std = []
-
 [dependencies]
 smart-leds-trait = { version = "0.3", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-sys = { version = "0.35", features = ["binstart"] }
-esp-idf-hal = "0.44"
+esp-idf-hal = { version = "0.44", default-features = false }
+esp-idf-sys = { version = "0.35", default-features = false }
+
+[features]
+default = ["std"]
+std = [ "alloc", "esp-idf-hal/std", "esp-idf-sys/std" ]
+alloc = [ "esp-idf-hal/alloc" ]
 
 [dev-dependencies]
 smart-leds = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ repository = "https://github.com/cat-in-136/ws2812-esp32-rmt-smart-leds"
 edition = "2021"
 
 [features]
+default = ["std"]
+std = []
 
 [dependencies]
 smart-leds-trait = { version = "0.3", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
-snafu = "0.8"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
 esp-idf-sys = { version = "0.35", features = ["binstart"] }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Support for `no_std` is still incomplete. Because a memory allocator (heap) is r
 For example, `default-feature = false, features = ["alloc", "smart-leds-trait"]` to enable smart-leds API
 `ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment.
 
+This library is intended for use with espidf.
+For bare-metal environments (i.e. use with [esp-hal](https://crates.io/crates/esp-hal/)),
+use the espressif official crate [esp-hal-smartled](https://crates.io/crates/esp-hal-smartled).
+
 ## Development
 
 To run the test locally, specify the local toolchain (`stable`, `nightly`, etc...) and target explicitly and disable

--- a/README.md
+++ b/README.md
@@ -51,10 +51,28 @@ $ cargo espflash
 
 ## Features
 
+|Features                |Default|Description                                                           |
+|------------------------|-------|----------------------------------------------------------------------|
+|`embedded_graphics_core`|       |embedded-graphics API `ws2812_esp32_rmt_driver::lib_embedded_graphics`|
+|`smart-leds-trait`      |       |smart-leds API `ws2812_esp32_rmt_driver::lib_smart_leds`              |
+|`std`                   |x      |use standard library `std`                                            |
+|`alloc`                 |x      |use memory allocator (heap)                                           |
+
+Some examples:
+
 * `features = ["embedded-graphics-core"]` to enable embedded-graphics
   API `ws2812_esp32_rmt_driver::lib_embedded_graphics`.
 * `features = ["smart-leds-trait"]` to enable smart-leds API `ws2812_esp32_rmt_driver::lib_smart_leds`.
 * default feature to enable just only driver API.
+
+## no_std
+
+To use `no_std`, disable `default` feature. Then, `std` feature is disabled and this library get compatible with `no_std`.
+
+Support for `no_std` is still incomplete. Because a memory allocator (heap) is required as of now, the `alloc` feature MUST be enabled.
+
+For example, `default-feature = false, features = ["alloc", "smart-leds-trait"]` to enable smart-leds API
+`ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,23 @@ Some examples:
 
 To use `no_std`, disable `default` feature. Then, `std` feature is disabled and this library get compatible with `no_std`.
 
-Support for `no_std` is still incomplete. Because a memory allocator (heap) is required as of now, the `alloc` feature MUST be enabled.
+Some examples:
 
-For example, `default-feature = false, features = ["alloc", "smart-leds-trait"]` to enable smart-leds API
-`ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment.
+*  `default-feature = false, features = ["alloc", "embedded-graphics-core"]` to enable embedded-graphics API
+   `ws2812_esp32_rmt_driver::lib_embedded_graphics` for `no_std` environment with memory allocator.
+*  `default-feature = false, features = ["alloc", "smart-leds-trait"]` to enable smart-leds API
+   `ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment with memory allocator.
+*  `default-feature = false, features = ["embedded-graphics-core"]` to enable embedded-graphics API
+   `ws2812_esp32_rmt_driver::lib_embedded_graphics` for `no_std` environment without memory allocator.
+*  `default-feature = false, features = ["smart-leds-trait"]` to enable smart-leds API
+   `ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment without memory allocator.
+
+When using the memory allocator (heap), enable the `alloc` feature. In this case, most processing works in the same way as `std`.
+When not using the memory allocator (heap), leave the `alloc` feature disabled. In this case,
+some APIs cannot be used and processing must be changed.
+For example, in the embedded-graphics API, the pixel data storage must be prepared by the programmer
+using heapless `Vec`-like struct such as `heapless::Vec<u8, X>`.
+
 
 This library is intended for use with espidf.
 For bare-metal environments (i.e. use with [esp-hal](https://crates.io/crates/esp-hal/)),

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -4,6 +4,7 @@ use esp_idf_hal::rmt::config::TransmitConfig;
 use esp_idf_hal::rmt::{PinState, Pulse, RmtChannel, Symbol, TxRmtDriver};
 use esp_idf_hal::units::Hertz;
 use esp_idf_sys::EspError;
+use snafu::prelude::*;
 use std::time::Duration;
 
 /// T0H duration time (0 code, high voltage time)
@@ -77,9 +78,11 @@ impl Ws2812Esp32RmtItemEncoder {
 }
 
 /// WS2812 ESP32 RMT Driver error.
-#[derive(thiserror::Error, Debug)]
-#[error(transparent)]
-pub struct Ws2812Esp32RmtDriverError(#[from] EspError);
+#[derive(Snafu, Debug)]
+#[snafu(transparent)]
+pub struct Ws2812Esp32RmtDriverError {
+    source: EspError,
+}
 
 /// WS2812 ESP32 RMT driver wrapper.
 pub struct Ws2812Esp32RmtDriver<'d> {

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -88,6 +88,16 @@ pub struct Ws2812Esp32RmtDriverError {
     source: EspError,
 }
 
+#[cfg(not(feature = "std"))]
+impl Ws2812Esp32RmtDriverError {
+    /// The `EspError` source of this error, if any.
+    ///
+    /// This is a workaround function until `core::error::Error` added.
+    pub fn source(&self) -> Option<&EspError> {
+        Some(&self.source)
+    }
+}
+
 #[cfg(feature = "std")]
 impl Error for Ws2812Esp32RmtDriverError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -1,11 +1,15 @@
+use core::convert::From;
+use core::fmt;
+use core::time::Duration;
 use esp_idf_hal::gpio::OutputPin;
 use esp_idf_hal::peripheral::Peripheral;
 use esp_idf_hal::rmt::config::TransmitConfig;
 use esp_idf_hal::rmt::{PinState, Pulse, RmtChannel, Symbol, TxRmtDriver};
 use esp_idf_hal::units::Hertz;
 use esp_idf_sys::EspError;
-use std::convert::From;
-use std::time::Duration;
+
+#[cfg(feature = "std")]
+use std::error::Error;
 
 /// T0H duration time (0 code, high voltage time)
 const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
@@ -85,14 +89,14 @@ pub struct Ws2812Esp32RmtDriverError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Ws2812Esp32RmtDriverError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl Error for Ws2812Esp32RmtDriverError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         Some(&self.source)
     }
 }
 
-impl std::fmt::Display for Ws2812Esp32RmtDriverError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Ws2812Esp32RmtDriverError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.source.fmt(f)
     }
 }

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -190,6 +190,7 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// Iteration of `pixel_sequence` happens inside an interrupt handler so beware of side-effects
     /// that don't work in interrupt handlers.
     /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter()] for details.
+    #[cfg(feature = "alloc")]
     pub fn write<'b, T>(
         &'static mut self,
         pixel_sequence: T,

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -79,6 +79,7 @@ impl Ws2812Esp32RmtItemEncoder {
 
 /// WS2812 ESP32 RMT Driver error.
 #[derive(Snafu, Debug)]
+#[repr(transparent)]
 #[snafu(transparent)]
 pub struct Ws2812Esp32RmtDriverError {
     source: EspError,

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -4,7 +4,7 @@ use esp_idf_hal::rmt::config::TransmitConfig;
 use esp_idf_hal::rmt::{PinState, Pulse, RmtChannel, Symbol, TxRmtDriver};
 use esp_idf_hal::units::Hertz;
 use esp_idf_sys::EspError;
-use snafu::prelude::*;
+use std::convert::From;
 use std::time::Duration;
 
 /// T0H duration time (0 code, high voltage time)
@@ -78,11 +78,29 @@ impl Ws2812Esp32RmtItemEncoder {
 }
 
 /// WS2812 ESP32 RMT Driver error.
-#[derive(Snafu, Debug)]
+#[derive(Debug)]
 #[repr(transparent)]
-#[snafu(transparent)]
 pub struct Ws2812Esp32RmtDriverError {
     source: EspError,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Ws2812Esp32RmtDriverError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl std::fmt::Display for Ws2812Esp32RmtDriverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+impl From<EspError> for Ws2812Esp32RmtDriverError {
+    fn from(source: EspError) -> Self {
+        Self { source }
+    }
 }
 
 /// WS2812 ESP32 RMT driver wrapper.

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -1,8 +1,9 @@
+use snafu::prelude::*;
 use std::marker::PhantomData;
 
 /// WS2812 ESP32 RMT Driver error.
-#[derive(thiserror::Error, Debug)]
-#[error("mock Ws2812Esp32RmtDriverError")]
+#[derive(Snafu, Debug)]
+#[snafu(display("mock Ws2812Esp32RmtDriverError"))]
 pub struct Ws2812Esp32RmtDriverError;
 
 /// Mock of Low-level WS2812 ESP32 RMT driver.

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -1,14 +1,18 @@
-use std::marker::PhantomData;
+use core::fmt;
+use core::marker::PhantomData;
+
+#[cfg(feature = "std")]
+use std::error::Error;
 
 /// WS2812 ESP32 RMT Driver error.
 #[derive(Debug)]
 pub struct Ws2812Esp32RmtDriverError;
 
 #[cfg(feature = "std")]
-impl std::error::Error for Ws2812Esp32RmtDriverError {}
+impl Error for Ws2812Esp32RmtDriverError {}
 
-impl std::fmt::Display for Ws2812Esp32RmtDriverError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Ws2812Esp32RmtDriverError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "mock Ws2812Esp32RmtDriverError")
     }
 }

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use core::marker::PhantomData;
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::error::Error;
 

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -1,10 +1,17 @@
-use snafu::prelude::*;
 use std::marker::PhantomData;
 
 /// WS2812 ESP32 RMT Driver error.
-#[derive(Snafu, Debug)]
-#[snafu(display("mock Ws2812Esp32RmtDriverError"))]
+#[derive(Debug)]
 pub struct Ws2812Esp32RmtDriverError;
+
+#[cfg(feature = "std")]
+impl std::error::Error for Ws2812Esp32RmtDriverError {}
+
+impl std::fmt::Display for Ws2812Esp32RmtDriverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "mock Ws2812Esp32RmtDriverError")
+    }
+}
 
 /// Mock of Low-level WS2812 ESP32 RMT driver.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
+extern crate heapless;
 
 pub mod driver;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
-extern crate heapless;
 
 pub mod driver;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
 
 pub mod driver;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -11,6 +11,9 @@ use embedded_graphics_core::Pixel;
 #[cfg(target_vendor = "espressif")]
 use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+
 /// LED pixel shape
 pub trait LedPixelShape {
     /// Returns the number of pixels
@@ -77,7 +80,7 @@ where
         pin: impl Peripheral<P = impl OutputPin> + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
-        let data = std::iter::repeat(0)
+        let data = core::iter::repeat(0)
             .take(S::pixel_len() * CDev::BPP)
             .collect::<Vec<_>>();
         Ok(Self {
@@ -93,7 +96,7 @@ where
     #[cfg(not(target_vendor = "espressif"))]
     pub fn new() -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new()?;
-        let data = std::iter::repeat(0)
+        let data = core::iter::repeat(0)
             .take(S::pixel_len() * CDev::BPP)
             .collect::<Vec<_>>();
         Ok(Self {
@@ -252,7 +255,7 @@ mod test {
         assert_eq!(draw.changed, true);
         assert_eq!(
             draw.data,
-            std::iter::repeat(0).take(150).collect::<Vec<_>>()
+            core::iter::repeat(0).take(150).collect::<Vec<_>>()
         );
     }
 
@@ -280,7 +283,7 @@ mod test {
         assert_eq!(draw.changed, true);
         assert_eq!(
             draw.data,
-            std::iter::repeat([0x08, 0x07, 0x0A])
+            core::iter::repeat([0x08, 0x07, 0x0A])
                 .take(50)
                 .flatten()
                 .collect::<Vec<_>>()

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -2,11 +2,11 @@
 
 use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
+use core::marker::PhantomData;
 use embedded_graphics_core::draw_target::DrawTarget;
 use embedded_graphics_core::geometry::{OriginDimensions, Point, Size};
 use embedded_graphics_core::pixelcolor::{Rgb888, RgbColor};
 use embedded_graphics_core::Pixel;
-use std::marker::PhantomData;
 
 #[cfg(target_vendor = "espressif")]
 use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -2,14 +2,14 @@
 
 use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
-use core::marker::PhantomData;
-use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
-
-#[cfg(target_vendor = "espressif")]
-use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};
-
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
+use core::marker::PhantomData;
+#[cfg(target_vendor = "espressif")]
+use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};
+#[cfg(feature = "alloc")]
+use smart_leds_trait::SmartLedsWrite;
+use smart_leds_trait::{RGB8, RGBW};
 
 /// 8-bit RGBW (RGB + white)
 pub type RGBW8 = RGBW<u8, u8>;
@@ -112,6 +112,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'d, CSmart, CDev> SmartLedsWrite for LedPixelEsp32Rmt<'d, CSmart, CDev>
 where
     CDev: LedPixelColor + From<CSmart>,

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -2,8 +2,8 @@
 
 use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
+use core::marker::PhantomData;
 use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
-use std::marker::PhantomData;
 
 #[cfg(target_vendor = "espressif")]
 use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -8,6 +8,9 @@ use smart_leds_trait::{SmartLedsWrite, RGB8, RGBW};
 #[cfg(target_vendor = "espressif")]
 use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
+
 /// 8-bit RGBW (RGB + white)
 pub type RGBW8 = RGBW<u8, u8>;
 


### PR DESCRIPTION
Support for `no_std`. This PR contains both `alloc` and non-`alloc`.

* `std`: no code change required. `default` feature has now `std` feature. 
* `no_std` with `alloc`: `no-default-feature` and `alloc` feature is required.
* `no_std` without `alloc`: `no-default-feature` and *not* specify `alloc`. heap-related process need to be modified e.g., switch to use `heapless::Vec`

to resolve #50