### PR TITLE
fix: use alloc::vec::Vec when `alloc` is used

### DIFF
--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -25,6 +25,10 @@ use esp_idf_hal::{
 use crate::mock::esp_idf_sys;
 use esp_idf_sys::EspError;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+
 /// T0H duration time (0 code, high voltage time)
 const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
 /// T0L duration time (0 code, low voltage time)

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -28,7 +28,6 @@ use esp_idf_sys::EspError;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-
 /// T0H duration time (0 code, high voltage time)
 const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
 /// T0L duration time (0 code, low voltage time)


### PR DESCRIPTION
The code didn't compile with `default-features = false, features=["alloc", "smart-leds-trait"]` before.

Either I'm missing something, or there might be some compilation issues with the suggested features mentioned in the documentation