### PR TITLE
introduce new_with_rmt_driver() to be able to use multiple mem blocks for TxRmtDriver to mitigate flickering

### DIFF
--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -195,6 +195,23 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
             let config = TransmitConfig::new().clock_divider(1);
             let tx = TxRmtDriver::new(channel, pin, &config)?;
 
+            Self::new_with_rmt_driver(tx)
+        }
+        #[cfg(not(target_vendor = "espressif"))] // Mock implement
+        {
+            let config = TransmitConfig::new();
+            let tx = TxRmtDriver::new(channel, pin, &config)?;
+            Ok(Self {
+                tx,
+                pixel_data: None,
+                phantom: Default::default(),
+            })
+        }
+    }
+
+    pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        #[cfg(target_vendor = "espressif")]
+        {
             let clock_hz = tx.counter_clock()?;
             let encoder = Ws2812Esp32RmtItemEncoder::new(clock_hz)?;
 
@@ -202,8 +219,6 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         }
         #[cfg(not(target_vendor = "espressif"))] // Mock implement
         {
-            let config = TransmitConfig::new();
-            let tx = TxRmtDriver::new(channel, pin, &config)?;
             Ok(Self {
                 tx,
                 pixel_data: None,

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -8,6 +8,7 @@ use embedded_graphics_core::draw_target::DrawTarget;
 use embedded_graphics_core::geometry::{OriginDimensions, Point, Size};
 use embedded_graphics_core::pixelcolor::{Rgb888, RgbColor};
 use embedded_graphics_core::Pixel;
+use esp_idf_hal::rmt::TxRmtDriver;
 
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_hal;
@@ -114,6 +115,23 @@ where
         pin: impl Peripheral<P = impl OutputPin> + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
+        let data = core::iter::repeat(0)
+            .take(S::pixel_len() * CDev::BPP)
+            .collect::<Data>();
+        Ok(Self {
+            driver,
+            data,
+            brightness: u8::MAX,
+            changed: true,
+            _phantom: Default::default(),
+        })
+    }
+
+    /// Create a new draw target.
+    pub fn new_with_rmt_driver(
+        tx: TxRmtDriver<'d>,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let driver = Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?;
         let data = core::iter::repeat(0)
             .take(S::pixel_len() * CDev::BPP)
             .collect::<Data>();

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -94,7 +94,7 @@ where
     }
 
     /// Create a new driver wrapper.
-    pub fn new_with_rmt_driver<C: RmtChannel>(
+    pub fn new_with_rmt_driver(
         tx: TxRmtDriver<'d>,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?;

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -4,6 +4,7 @@ use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl}
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
+use esp_idf_hal::rmt::TxRmtDriver;
 use core::marker::PhantomData;
 #[cfg(feature = "alloc")]
 use smart_leds_trait::SmartLedsWrite;
@@ -86,6 +87,17 @@ where
         pin: impl Peripheral<P = impl OutputPin> + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
+        Ok(Self {
+            driver,
+            phantom: Default::default(),
+        })
+    }
+
+    /// Create a new driver wrapper.
+    pub fn new_with_rmt_driver<C: RmtChannel>(
+        tx: TxRmtDriver<'d>,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let driver = Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?;
         Ok(Self {
             driver,
             phantom: Default::default(),


### PR DESCRIPTION
I had the issue that my output was flickering like describe over here: https://github.com/cat-in-136/ws2812-esp32-rmt-driver/issues/33

Using two mem blocks solved the flickering entirely for me (and i think for many others).