### PR TITLE
Make duration configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ smart-leds = "0.4"
 embedded-graphics = "0.8"
 
 [build-dependencies]
-embuild = "0.32"
+embuild = "0.33"
 
 [profile.release]
 strip = true

--- a/examples/smart_leds_pl9823_rgb.rs
+++ b/examples/smart_leds_pl9823_rgb.rs
@@ -16,10 +16,11 @@ fn main() -> ! {
     // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
     esp_idf_sys::link_patches();
 
-    const WS2811_T0H_NS: Duration = Duration::from_nanos(350);
-    const WS2811_T0L_NS: Duration = Duration::from_nanos(1360);
-    const WS2811_T1H_NS: Duration = Duration::from_nanos(1360);
-    const WS2811_T1L_NS: Duration = Duration::from_nanos(350);
+    // Shenzhen Rita Lighting PL2823
+    const PL9823_T0H_NS: Duration = Duration::from_nanos(350);
+    const PL9823_T0L_NS: Duration = Duration::from_nanos(1360);
+    const PL9823_T1H_NS: Duration = Duration::from_nanos(1360);
+    const PL9823_T1L_NS: Duration = Duration::from_nanos(350);
 
     let peripherals = Peripherals::take().unwrap();
     let led_pin = peripherals.pins.gpio25;
@@ -30,10 +31,10 @@ fn main() -> ! {
     let ws2812_driver = Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx_driver)
         .unwrap()
         .encoder_duration(
-            &WS2811_T0H_NS,
-            &WS2811_T0L_NS,
-            &WS2811_T1H_NS,
-            &WS2811_T1L_NS,
+            &PL9823_T0H_NS,
+            &PL9823_T0L_NS,
+            &PL9823_T1H_NS,
+            &PL9823_T1L_NS,
         )
         .unwrap()
         .build()

--- a/examples/smart_leds_ws2811_rgb.rs
+++ b/examples/smart_leds_ws2811_rgb.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "smart-leds-trait")]
+use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_hal::rmt::config::TransmitConfig;
+use esp_idf_hal::rmt::TxRmtDriver;
+use esp_idf_hal::sys::esp_random;
+use smart_leds::hsv::{hsv2rgb, Hsv};
+use smart_leds_trait::{SmartLedsWrite, RGB8};
+use std::thread::sleep;
+use std::time::Duration;
+use ws2812_esp32_rmt_driver::driver::color::LedPixelColorRgb24;
+use ws2812_esp32_rmt_driver::driver::Ws2812Esp32RmtDriverBuilder;
+use ws2812_esp32_rmt_driver::LedPixelEsp32Rmt;
+
+fn main() -> ! {
+    // Temporary. Will disappear once ESP-IDF 4.4 is released, but for now it is necessary to call this function once,
+    // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
+    esp_idf_sys::link_patches();
+
+    const WS2811_T0H_NS: Duration = Duration::from_nanos(350);
+    const WS2811_T0L_NS: Duration = Duration::from_nanos(1360);
+    const WS2811_T1H_NS: Duration = Duration::from_nanos(1360);
+    const WS2811_T1L_NS: Duration = Duration::from_nanos(350);
+
+    let peripherals = Peripherals::take().unwrap();
+    let led_pin = peripherals.pins.gpio25;
+    let channel = peripherals.rmt.channel0;
+
+    let driver_config = TransmitConfig::new().clock_divider(1); // Required parameter.
+    let tx_driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
+    let ws2812_driver = Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx_driver)
+        .unwrap()
+        .encoder_duration(
+            &WS2811_T0H_NS,
+            &WS2811_T0L_NS,
+            &WS2811_T1H_NS,
+            &WS2811_T1L_NS,
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+    let mut ws2812 =
+        LedPixelEsp32Rmt::<RGB8, LedPixelColorRgb24>::new_with_ws2812_driver(ws2812_driver)
+            .unwrap();
+
+    let mut hue = unsafe { esp_random() } as u8;
+    loop {
+        let pixels = std::iter::repeat(hsv2rgb(Hsv {
+            hue,
+            sat: 255,
+            val: 8,
+        }))
+        .take(25);
+        ws2812.write(pixels).unwrap();
+
+        sleep(Duration::from_millis(100));
+
+        hue = hue.wrapping_add(10);
+    }
+}

--- a/src/driver/color.rs
+++ b/src/driver/color.rs
@@ -198,6 +198,18 @@ fn test_led_pixel_color_brightness() {
 /// ```
 pub type LedPixelColorGrb24 = LedPixelColorImpl<3, 1, 0, 2, 255>;
 
+/// 8-bit RGB LED pixel color (total 32-bit pixel)
+///
+/// # Examples
+///
+/// ```
+/// use ws2812_esp32_rmt_driver::driver::color::{LedPixelColorRgb24, LedPixelColor};
+///
+/// let color = LedPixelColorGrb24::new_with_rgb(1, 2, 3);
+/// assert_eq!(color.as_ref(), [1, 2, 3]);
+/// ```
+pub type LedPixelColorRgb24 = LedPixelColorImpl<3, 0, 1, 2, 255>;
+
 /// 8-bit RGBW LED pixel color (total 32-bit pixel)
 ///
 /// # Examples

--- a/src/driver/color.rs
+++ b/src/driver/color.rs
@@ -205,7 +205,7 @@ pub type LedPixelColorGrb24 = LedPixelColorImpl<3, 1, 0, 2, 255>;
 /// ```
 /// use ws2812_esp32_rmt_driver::driver::color::{LedPixelColorRgb24, LedPixelColor};
 ///
-/// let color = LedPixelColorGrb24::new_with_rgb(1, 2, 3);
+/// let color = LedPixelColorRgb24::new_with_rgb(1, 2, 3);
 /// assert_eq!(color.as_ref(), [1, 2, 3]);
 /// ```
 pub type LedPixelColorRgb24 = LedPixelColorImpl<3, 0, 1, 2, 255>;

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -151,19 +151,27 @@ impl From<EspError> for Ws2812Esp32RmtDriverError {
 /// # #[cfg(not(target_vendor = "espressif"))]
 /// # use ws2812_esp32_rmt_driver::mock::esp_idf_hal;
 /// #
+/// # use core::time::Duration;
 /// # use esp_idf_hal::peripherals::Peripherals;
 /// # use esp_idf_hal::rmt::config::TransmitConfig;
 /// # use esp_idf_hal::rmt::TxRmtDriver;
+/// # use ws2812_esp32_rmt_driver::driver::Ws2812Esp32RmtDriverBuilder;
 /// #
 /// # let peripherals = Peripherals::take().unwrap();
 /// # let led_pin = peripherals.pins.gpio27;
 /// # let channel = peripherals.rmt.channel0;
-/// #
-/// let tx_driver_config = TransmitConfig::new()
+///
+/// // WS2812B timing parameters.
+/// const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
+/// const WS2812_T0L_NS: Duration = Duration::from_nanos(850);
+/// const WS2812_T1H_NS: Duration = Duration::from_nanos(800);
+/// const WS2812_T1L_NS: Duration = Duration::from_nanos(450);
+///
+/// let driver_config = TransmitConfig::new()
 ///     .clock_divider(1); // Required parameter.
 /// let tx_driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-/// let builder = Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx_driver).unwrap()
-///    .encoder_duration(400, 850, 800, 450).unwrap()
+/// let driver = Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx_driver).unwrap()
+///    .encoder_duration(&WS2812_T0H_NS, &WS2812_T0L_NS, &WS2812_T1H_NS, &WS2812_T1L_NS).unwrap()
 ///    .build().unwrap();
 /// ```
 pub struct Ws2812Esp32RmtDriverBuilder<'d> {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -4,4 +4,5 @@ pub mod color;
 mod esp32_rmt;
 
 pub use esp32_rmt::Ws2812Esp32RmtDriver;
+pub use esp32_rmt::Ws2812Esp32RmtDriverBuilder;
 pub use esp32_rmt::Ws2812Esp32RmtDriverError;

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -115,16 +115,7 @@ where
         pin: impl Peripheral<P = impl OutputPin> + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
-        let data = core::iter::repeat(0)
-            .take(S::pixel_len() * CDev::BPP)
-            .collect::<Data>();
-        Ok(Self {
-            driver,
-            data,
-            brightness: u8::MAX,
-            changed: true,
-            _phantom: Default::default(),
-        })
+        Self::new_with_ws2812_driver(driver)
     }
 
     /// Create a new draw target with `TxRmtDriver`.
@@ -149,6 +140,12 @@ where
     /// ```
     pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?;
+        Self::new_with_ws2812_driver(driver)
+    }
+
+    pub fn new_with_ws2812_driver(
+        driver: Ws2812Esp32RmtDriver<'d>,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let data = core::iter::repeat(0)
             .take(S::pixel_len() * CDev::BPP)
             .collect::<Data>();

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -86,11 +86,9 @@ where
         channel: impl Peripheral<P = C> + 'd,
         pin: impl Peripheral<P = impl OutputPin> + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
-        Ok(Self {
-            driver,
-            phantom: Default::default(),
-        })
+        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new(
+            channel, pin,
+        )?)
     }
 
     /// Create a new driver wrapper with `TxRmtDriver`.
@@ -114,7 +112,13 @@ where
     /// let driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
     /// ```
     pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let driver = Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?;
+        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?)
+    }
+
+    /// Create a new driver wrapper with `Ws2812Esp32RmtDriver`.
+    pub fn new_with_ws2812_driver(
+        driver: Ws2812Esp32RmtDriver<'d>,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         Ok(Self {
             driver,
             phantom: Default::default(),

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -86,9 +86,7 @@ where
         channel: impl Peripheral<P = C> + 'd,
         pin: impl Peripheral<P = impl OutputPin> + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new(
-            channel, pin,
-        )?)
+        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?)
     }
 
     /// Create a new driver wrapper with `TxRmtDriver`.

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -110,6 +110,7 @@ pub mod esp_idf_hal {
         use super::gpio::OutputPin;
         use super::peripheral::Peripheral;
         use super::sys::EspError;
+        use super::units::Hertz;
         use config::TransmitConfig;
         use core::marker::PhantomData;
         use paste::paste;
@@ -178,6 +179,11 @@ pub mod esp_idf_hal {
             ) -> Result<Self, EspError> {
                 Ok(Self { _p: PhantomData })
             }
+
+            pub fn counter_clock(&self) -> Result<Hertz, EspError> {
+                let ticks_hz: u32 = 80000000; // 80MHz
+                Ok(Hertz(ticks_hz))
+            }
         }
 
         /// Mock module for `esp_idf_hal::rmt::config`
@@ -209,6 +215,16 @@ pub mod esp_idf_hal {
                 }
             }
         }
+    }
+
+    /// Mock module for `esp_idf_hal::units`
+    pub mod units {
+        pub type ValueType = u32;
+        pub type LargeValueType = u64;
+
+        /// Mock struct for `esp_idf_hal::units::Hertz`
+        #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Default)]
+        pub struct Hertz(pub ValueType);
     }
 }
 


### PR DESCRIPTION
Make the pulse duration time of T0H, T0L, T1H and T1L configurable to support for other smart LED such as WS2811.
To do this, `Ws2812Esp32RmtDriverBuilder` trait is introduced and new_with_ws2812_driver functions for smartled and embeddedgraphics interface.

This PR will close #66.