### PR TITLE
docs: replace doc_auto_cfg with doc_cfg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,9 +7,7 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Install Rust for Xtensa
       uses: esp-rs/xtensa-toolchain@v1.6
@@ -17,7 +15,7 @@ jobs:
         default: true
         version: "1.90.0"
         ldproxy: true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         path: ws2812-esp32-rmt-driver
     - uses: actions/cache@v4
@@ -39,6 +37,24 @@ jobs:
     - name: Build examples
       run: cargo build --examples --all-features --features=esp-idf-sys/binstart #--release
       working-directory: ./ws2812-esp32-rmt-driver
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        path: ws2812-esp32-rmt-driver
+    - name: Install Rust (stable)
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ws2812-esp32-rmt-driver/target
+        key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Test
       run: |
         cargo +stable test --target x86_64-unknown-linux-gnu --lib
@@ -50,3 +66,4 @@ jobs:
     - name: Publish (Dry run)
       run: cargo +stable publish --target x86_64-unknown-linux-gnu --dry-run
       working-directory: ./ws2812-esp32-rmt-driver
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/138907 made doc_auto_cfg feature replaced with doc_cfg. This cause docs.rs error.

```
# rustc version
[INFO] [stderr] warning: Rustdoc did not scrape the following examples because they require dev-dependencies: m5atom_embedded_graphics, m5atom_smart_leds, smart_leds_pl9823_rgb, smart_leds_sk6812_rgbw
[INFO] [stderr]     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
[INFO] [stderr]     to the [[example]] target configuration of at least one example.
[INFO] [stderr] warning: target filter specified, but no targets matched; this is a no-op
[INFO] [stderr]  Documenting ws2812-esp32-rmt-driver v0.13.0 (/opt/rustwide/workdir)
[INFO] [stderr] error[E0557]: feature has been removed
[INFO] [stderr]  --> src/lib.rs:2:29
[INFO] [stderr]   |
[INFO] [stderr] 2 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
[INFO] [stderr]   |                             ^^^^^^^^^^^^ feature has been removed
[INFO] [stderr]   |
[INFO] [stderr]   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
[INFO] [stderr]   = note: merged into `doc_cfg`
```