### PR TITLE
Update esp-idf-hal to 0.46 (and esp-idf-sys to 0.37)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ embedded-graphics-core = { version = "0.4", optional = true }
 heapless = "0.8"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-hal = { version = "0.45", default-features = false, features = ['rmt-legacy'] }
-esp-idf-sys = { version = "0.36", default-features = false }
+esp-idf-hal = { version = "0.46", default-features = false, features = ['rmt-legacy'] }
+esp-idf-sys = { version = "0.37", default-features = false }
 
 [target.'cfg(not(target_vendor = "espressif"))'.dependencies]
 paste = "1"

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -14,7 +14,6 @@ use crate::mock::esp_idf_hal;
 use esp_idf_hal::rmt::{PinState, Pulse, Symbol};
 use esp_idf_hal::{
     gpio::OutputPin,
-    peripheral::Peripheral,
     rmt::{config::TransmitConfig, RmtChannel, TxRmtDriver},
     units::Hertz,
 };
@@ -183,9 +182,9 @@ pub struct Ws2812Esp32RmtDriverBuilder<'d> {
 
 impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
     /// Creates a new `Ws2812Esp32RmtDriverBuilder`.
-    pub fn new<C: RmtChannel>(
-        channel: impl Peripheral<P = C> + 'd,
-        pin: impl Peripheral<P = impl OutputPin> + 'd,
+    pub fn new<C: RmtChannel + 'd>(
+        channel: C,
+        pin: impl OutputPin + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let config = TransmitConfig::new().clock_divider(1);
         let tx = TxRmtDriver::new(channel, pin, &config)?;
@@ -301,9 +300,9 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// # Errors
     ///
     /// Returns an error if the RMT driver initialization failed.
-    pub fn new<C: RmtChannel>(
-        channel: impl Peripheral<P = C> + 'd,
-        pin: impl Peripheral<P = impl OutputPin> + 'd,
+    pub fn new<C: RmtChannel + 'd>(
+        channel: C,
+        pin: impl OutputPin + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         Ws2812Esp32RmtDriverBuilder::new(channel, pin)?.build()
     }

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -12,7 +12,7 @@ use esp_idf_hal::rmt::TxRmtDriver;
 
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_hal;
-use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};
+use esp_idf_hal::{gpio::OutputPin, rmt::RmtChannel};
 
 /// LED pixel shape
 pub trait LedPixelShape {
@@ -110,9 +110,9 @@ where
     /// Create a new draw target.
     ///
     /// `channel` shall be different between different `pin`.
-    pub fn new<C: RmtChannel>(
-        channel: impl Peripheral<P = C> + 'd,
-        pin: impl Peripheral<P = impl OutputPin> + 'd,
+    pub fn new<C: RmtChannel + 'd>(
+        channel: C,
+        pin: impl OutputPin + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
         Self::new_with_ws2812_driver(driver)

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -12,7 +12,7 @@ use smart_leds_trait::{RGB8, RGBW};
 
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_hal;
-use esp_idf_hal::{gpio::OutputPin, peripheral::Peripheral, rmt::RmtChannel};
+use esp_idf_hal::{gpio::OutputPin, rmt::RmtChannel};
 
 /// 8-bit RGBW (RGB + white)
 pub type RGBW8 = RGBW<u8, u8>;
@@ -82,9 +82,9 @@ where
     /// Create a new driver wrapper.
     ///
     /// `channel` shall be different between different `pin`.
-    pub fn new<C: RmtChannel>(
-        channel: impl Peripheral<P = C> + 'd,
-        pin: impl Peripheral<P = impl OutputPin> + 'd,
+    pub fn new<C: RmtChannel + 'd>(
+        channel: C,
+        pin: impl OutputPin + 'd,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
         Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?)
     }

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -6,7 +6,6 @@ pub mod esp_idf_hal {
 
     /// Mock module for `esp_idf_hal::gpio`
     pub mod gpio {
-        use super::peripheral::Peripheral;
         use paste::paste;
 
         /// Mock trait for `esp_idf_hal::gpio::OutputPin`.
@@ -52,9 +51,6 @@ pub mod esp_idf_hal {
                         //}
 
                         impl OutputPin for [<Gpio $num>] {}
-                        impl Peripheral for [<Gpio $num>] {
-                            type P=[<Gpio $num>];
-                        }
                     )*
                 }
             };
@@ -64,15 +60,6 @@ pub mod esp_idf_hal {
             24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
             46, 47, 48
         );
-    }
-
-    /// Mock module for `esp_idf_hal::peripheral`
-    pub mod peripheral {
-        /// Mock trait for `esp_idf_hal::peripheral::Peripheral`
-        pub trait Peripheral: Sized {
-            /// Peripheral singleton type
-            type P;
-        }
     }
 
     /// Mock module for `esp_idf_hal::peripherals`
@@ -108,7 +95,6 @@ pub mod esp_idf_hal {
     /// Mock module for `esp_idf_hal::rmt`
     pub mod rmt {
         use super::gpio::OutputPin;
-        use super::peripheral::Peripheral;
         use super::sys::EspError;
         use super::units::Hertz;
         use config::TransmitConfig;
@@ -127,10 +113,6 @@ pub mod esp_idf_hal {
                             pub fn new() -> Self {
                                 Self {}
                             }
-                        }
-
-                        impl Peripheral for [<CHANNEL $num>] {
-                            type P=[<CHANNEL $num>];
                         }
 
                         impl RmtChannel for [<CHANNEL $num>] {}
@@ -172,9 +154,9 @@ pub mod esp_idf_hal {
         impl<'d> TxRmtDriver<'d> {
             /// Initialize the mock of `TxRmtDriver`.
             /// No argument is used in this mock.
-            pub fn new<C: RmtChannel>(
-                _channel: impl Peripheral<P = C> + 'd,
-                _pin: impl Peripheral<P = impl OutputPin> + 'd,
+            pub fn new<C: RmtChannel + 'd>(
+                _channel: C,
+                _pin: impl OutputPin + 'd,
                 _config: &TransmitConfig,
             ) -> Result<Self, EspError> {
                 Ok(Self { _p: PhantomData })


### PR DESCRIPTION
Started to play with esp32c6 and Rust, and my VROOM board has an RGB LED that is most easily supported by this crate -- but lacking support for the latest HAL.

I'm also toying with the idea of switching from `rmt-legacy` to `rmt`, as I assume the former may eventually disappear, but that's a much more significant change.

For transparency, patch generated by Claude, it's all very mechanical, doing basically what the PR linked below suggests.

---

The `Peripheral` trait was removed in esp-idf-hal 0.46, see https://github.com/esp-rs/esp-idf-hal/pull/529 for details

Update all `new()` signatures from `impl Peripheral<P = C> + 'd` to `C` (with `C: RmtChannel + 'd`), and `impl Peripheral<P = impl OutputPin> + 'd` to `impl OutputPin + 'd`. Remove the mock `peripheral` module accordingly.