### PR TITLE
Migrate from rmt-legacy to new RMT API

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,10 @@
 [build]
-# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2/-S3/-C3 or -C6)
 target = "xtensa-esp32-espidf"
 #target = "xtensa-esp32s2-espidf"
 #target = "xtensa-esp32s3-espidf"
 #target = "riscv32imc-esp-espidf"
+#target = "riscv32imac-esp-espidf"
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
@@ -15,9 +16,13 @@ linker = "ldproxy"
 runner = "espflash flash --monitor"
 rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
 
+[target.riscv32imac-esp-espidf]
+linker = "ldproxy"
+runner = "espflash flash --monitor"
+rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
+
 [unstable]
 build-std = ["std", "panic_abort"]
-build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF v5.5

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,7 +20,7 @@ build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]
 
 [env]
-# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF stable (v5.1)
-ESP_IDF_VERSION = { value = "branch:release/v5.1" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF v5.5
+ESP_IDF_VERSION = { value = "branch:release/v5.5" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master
 #ESP_IDF_VERSION = { value = "master" }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,6 @@ jobs:
       run: |
         cargo build
         cargo build --all-features
-        cargo build --no-default-features --features=alloc
-        cargo build --no-default-features --features=alloc,smart-leds-trait,embedded-graphics-core
         cargo build --no-default-features
         cargo build --no-default-features --features=smart-leds-trait,embedded-graphics-core
       working-directory: ./ws2812-esp32-rmt-driver

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ embedded-graphics-core = { version = "0.4", optional = true }
 heapless = "0.8"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-hal = { version = "0.46", default-features = false, features = ['rmt-legacy'] }
+esp-idf-hal = { version = "0.46", default-features = false }
 esp-idf-sys = { version = "0.37", default-features = false }
 
 [target.'cfg(not(target_vendor = "espressif"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ std = [ "esp-idf-hal/std", "esp-idf-sys/std" ]
 [dev-dependencies]
 smart-leds = "0.4"
 embedded-graphics = "0.8"
+log = "0.4"
+
+[target.'cfg(target_vendor = "espressif")'.dev-dependencies]
+esp-idf-svc = { version = "0.52", default-features = false, features = ["std", "binstart"] }
 
 [build-dependencies]
 embuild = "0.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,9 @@ rust-version = "1.82"
 [dependencies]
 smart-leds-trait = { version = "0.3", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
-heapless = "0.8"
 
 [target.'cfg(target_vendor = "espressif")'.dependencies]
-esp-idf-hal = { version = "0.46", default-features = false }
+esp-idf-hal = { version = "0.46", default-features = false, features = ["alloc"] }
 esp-idf-sys = { version = "0.37", default-features = false }
 
 [target.'cfg(not(target_vendor = "espressif"))'.dependencies]
@@ -26,8 +25,7 @@ paste = "1"
 
 [features]
 default = ["std"]
-std = [ "alloc", "esp-idf-hal/std", "esp-idf-sys/std" ]
-alloc = [ "esp-idf-hal/alloc" ]
+std = [ "esp-idf-hal/std", "esp-idf-sys/std" ]
 
 [dev-dependencies]
 smart-leds = "0.4"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ $ cargo espflash
 |`embedded_graphics_core`|       |embedded-graphics API `ws2812_esp32_rmt_driver::lib_embedded_graphics`|
 |`smart-leds-trait`      |       |smart-leds API `ws2812_esp32_rmt_driver::lib_smart_leds`              |
 |`std`                   |x      |use standard library `std`                                            |
-|`alloc`                 |x      |use memory allocator (heap)                                           |
 
 Some examples:
 
@@ -71,21 +70,12 @@ To use `no_std`, disable `default` feature. Then, `std` feature is disabled and 
 
 Some examples:
 
-*  `default-feature = false, features = ["alloc", "embedded-graphics-core"]` to enable embedded-graphics API
-   `ws2812_esp32_rmt_driver::lib_embedded_graphics` for `no_std` environment with memory allocator.
-*  `default-feature = false, features = ["alloc", "smart-leds-trait"]` to enable smart-leds API
-   `ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment with memory allocator.
 *  `default-feature = false, features = ["embedded-graphics-core"]` to enable embedded-graphics API
-   `ws2812_esp32_rmt_driver::lib_embedded_graphics` for `no_std` environment without memory allocator.
+   `ws2812_esp32_rmt_driver::lib_embedded_graphics` for `no_std` environment.
 *  `default-feature = false, features = ["smart-leds-trait"]` to enable smart-leds API
-   `ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment without memory allocator.
+   `ws2812_esp32_rmt_driver::lib_smart_leds` for `no_std` environment.
 
-When using the memory allocator (heap), enable the `alloc` feature. In this case, most processing works in the same way as `std`.
-When not using the memory allocator (heap), leave the `alloc` feature disabled. In this case,
-some APIs cannot be used and processing must be changed.
-For example, in the embedded-graphics API, the pixel data storage must be prepared by the programmer
-using heapless `Vec`-like struct such as `heapless::Vec<u8, X>`.
-
+The new `rmt` API in esp-idf-hal requires `alloc`, so we require that as well.
 
 This library is intended for use with espidf.
 For bare-metal environments (i.e. use with [esp-hal](https://crates.io/crates/esp-hal/)),

--- a/examples/m5atom_embedded_graphics.rs
+++ b/examples/m5atom_embedded_graphics.rs
@@ -14,9 +14,8 @@ fn main() -> ! {
 
     let peripherals = Peripherals::take().unwrap();
     let led_pin = peripherals.pins.gpio27;
-    let channel = peripherals.rmt.channel0;
 
-    let mut draw = Ws2812DrawTarget::<LedPixelMatrix<5, 5>>::new(channel, led_pin).unwrap();
+    let mut draw = Ws2812DrawTarget::<LedPixelMatrix<5, 5>>::new(led_pin).unwrap();
     draw.set_brightness(40);
 
     println!("Start Ws2812DrawTarget!");

--- a/examples/m5atom_smart_leds.rs
+++ b/examples/m5atom_smart_leds.rs
@@ -14,8 +14,7 @@ fn main() -> ! {
 
     let peripherals = Peripherals::take().unwrap();
     let led_pin = peripherals.pins.gpio27;
-    let channel = peripherals.rmt.channel0;
-    let mut ws2812 = Ws2812Esp32Rmt::new(channel, led_pin).unwrap();
+    let mut ws2812 = Ws2812Esp32Rmt::new(led_pin).unwrap();
 
     println!("Start NeoPixel rainbow!");
 

--- a/examples/queue_nonblocking.rs
+++ b/examples/queue_nonblocking.rs
@@ -1,0 +1,82 @@
+use esp_idf_hal::peripherals::Peripherals;
+use std::thread::sleep;
+use std::time::Duration;
+use ws2812_esp32_rmt_driver::driver::color::{LedPixelColor, LedPixelColorRgb24};
+use ws2812_esp32_rmt_driver::driver::Ws2812Esp32RmtDriver;
+
+const NUM_LEDS: usize = 1;
+
+fn main() -> ! {
+    esp_idf_svc::sys::link_patches();
+    esp_idf_svc::log::EspLogger::initialize_default();
+
+    log::info!("Initializing...");
+
+    let peripherals = Peripherals::take().unwrap();
+    let led_pin = peripherals.pins.gpio8;
+    let mut driver = Ws2812Esp32RmtDriver::new(led_pin).unwrap();
+    // Create a non-blocking transmission queue, be careful that it _will_ block if dropped.
+    let mut queue = driver.queue();
+
+    log::info!("Start (non-)blocking queue/push example!");
+
+    let mut brightness: u8 = 0;
+    loop {
+        // Build pixel buffer: pulsing red.
+        let color = LedPixelColorRgb24::new_with_rgb(brightness, 0, 0);
+        let pixel_bytes: [u8; 3] = color.as_ref().try_into().unwrap();
+        let pixel_data: Vec<u8> = pixel_bytes
+            .iter()
+            .copied()
+            .cycle()
+            .take(NUM_LEDS * 3)
+            .collect();
+
+        // This is more test code than example code. This demonstrates that the
+        // non-blocking write will fail if the previous transmission is still in progress.
+        log::info!("Calling push(), brightness={brightness}");
+        match queue.push(&pixel_data) {
+            Ok(()) => {
+                let mut i = 0;
+                // Since we do not block, this will fail a few times.
+                while queue.push(&pixel_data).is_err() {
+                    i += 1;
+                }
+                log::info!("Transmission failed {i} times after initial success.");
+            }
+            Err(e) => log::error!("write() error: {e}"),
+        }
+
+        // However, push_blocking... blocks.
+        log::info!("Calling push_blocking(), brightness={brightness}");
+        match queue.push_blocking(&pixel_data) {
+            Ok(()) => {
+                let mut i = 0;
+                // Since we block, this must immediately succeed.
+                while queue.push_blocking(&pixel_data).is_err() {
+                    i += 1;
+                }
+                if i == 0 {
+                    log::info!(
+                        "Blocking: Transmission succeeded immediately after initial success."
+                    );
+                } else {
+                    log::error!("Blocking: Transmission failed {i} times after initial success, that should not happen!");
+                }
+            }
+            Err(e) => log::error!("write() error: {e}"),
+        }
+
+        // This is more of a real example, push and do something else.
+        log::info!("Calling write(), brightness={brightness}");
+        match queue.push(&pixel_data) {
+            Ok(()) => {
+                log::info!("Transmission started, doing other work...");
+            }
+            Err(e) => log::error!("write() error: {e}"),
+        }
+
+        sleep(Duration::from_millis(100));
+        brightness = brightness.wrapping_add(20);
+    }
+}

--- a/examples/smart_leds_pl9823_rgb.rs
+++ b/examples/smart_leds_pl9823_rgb.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "smart-leds-trait")]
 use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_hal::rmt::config::TxChannelConfig;
 use esp_idf_hal::sys::esp_random;
+use esp_idf_hal::units::Hertz;
 use smart_leds::hsv::{hsv2rgb, Hsv};
 use smart_leds_trait::{SmartLedsWrite, RGB8};
 use std::thread::sleep;
@@ -23,7 +25,11 @@ fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
     let led_pin = peripherals.pins.gpio25;
 
-    let ws2812_driver = Ws2812Esp32RmtDriverBuilder::new(led_pin)
+    let config = TxChannelConfig {
+        resolution: Hertz(10_000_000),
+        ..Default::default()
+    };
+    let ws2812_driver = Ws2812Esp32RmtDriverBuilder::new_with_config(led_pin, &config)
         .unwrap()
         .encoder_duration(
             &PL9823_T0H_NS,

--- a/examples/smart_leds_pl9823_rgb.rs
+++ b/examples/smart_leds_pl9823_rgb.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "smart-leds-trait")]
 use esp_idf_hal::peripherals::Peripherals;
-use esp_idf_hal::rmt::config::TransmitConfig;
-use esp_idf_hal::rmt::TxRmtDriver;
 use esp_idf_hal::sys::esp_random;
 use smart_leds::hsv::{hsv2rgb, Hsv};
 use smart_leds_trait::{SmartLedsWrite, RGB8};
@@ -24,11 +22,8 @@ fn main() -> ! {
 
     let peripherals = Peripherals::take().unwrap();
     let led_pin = peripherals.pins.gpio25;
-    let channel = peripherals.rmt.channel0;
 
-    let driver_config = TransmitConfig::new().clock_divider(1); // Required parameter.
-    let tx_driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-    let ws2812_driver = Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx_driver)
+    let ws2812_driver = Ws2812Esp32RmtDriverBuilder::new(led_pin)
         .unwrap()
         .encoder_duration(
             &PL9823_T0H_NS,

--- a/examples/smart_leds_sk6812_rgbw.rs
+++ b/examples/smart_leds_sk6812_rgbw.rs
@@ -13,8 +13,7 @@ fn main() -> ! {
 
     let peripherals = Peripherals::take().unwrap();
     let led_pin = peripherals.pins.gpio26;
-    let channel = peripherals.rmt.channel0;
-    let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(channel, led_pin).unwrap();
+    let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(led_pin).unwrap();
 
     loop {
         let pixels = std::iter::repeat(RGBW8::new_alpha(6, 0, 0, White(0))).take(25);

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -24,9 +24,8 @@ use esp_idf_hal::{
 use crate::mock::esp_idf_sys;
 use esp_idf_sys::EspError;
 
-/// RMT clock resolution used for pulse timing.
-/// TODO: Is it ok to hardcode this? -- this matches HAL examples.
-const RMT_CLOCK_HZ: Hertz = Hertz(10_000_000); // 10 MHz
+/// Default RMT clock resolution used for pulse timing.
+const DEFAULT_RMT_CLOCK_HZ: Hertz = Hertz(10_000_000); // 10 MHz
 
 /// T0H duration time (0 code, high voltage time)
 const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
@@ -142,6 +141,8 @@ impl From<EspError> for Ws2812Esp32RmtDriverError {
 pub struct Ws2812Esp32RmtDriverBuilder<'d> {
     /// TxRMT driver.
     tx: TxChannelDriver<'d>,
+    /// RMT clock resolution, taken from the TxChannelConfig.
+    clock_hz: Hertz,
     /// BytesEncoder with WS2812 timing configuration.
     encoder: Option<BytesEncoder>,
 }
@@ -150,11 +151,23 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
     /// Creates a new `Ws2812Esp32RmtDriverBuilder`.
     pub fn new(pin: impl OutputPin + 'd) -> Result<Self, Ws2812Esp32RmtDriverError> {
         let config = TxChannelConfig {
-            resolution: RMT_CLOCK_HZ,
+            resolution: DEFAULT_RMT_CLOCK_HZ,
             ..Default::default()
         };
-        let tx = TxChannelDriver::new(pin, &config)?;
-        Ok(Self { tx, encoder: None })
+        Self::new_with_config(pin, &config)
+    }
+
+    /// Creates a new `Ws2812Esp32RmtDriverBuilder` with a custom `TxChannelConfig`.
+    pub fn new_with_config(
+        pin: impl OutputPin + 'd,
+        config: &TxChannelConfig,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let tx = TxChannelDriver::new(pin, config)?;
+        Ok(Self {
+            tx,
+            clock_hz: config.resolution,
+            encoder: None,
+        })
     }
 
     /// Sets the encoder duration times.
@@ -166,8 +179,6 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
     /// * `t1h` - T1H duration time (1 code, high voltage time)
     /// * `t1l` - T1L duration time (1 code, low voltage time)
     ///
-    /// Note: the clock resolution is fixed at 10 MHz.
-    ///
     /// # Errors
     ///
     /// Returns an error if the encoder initialization failed.
@@ -178,7 +189,7 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
         t1h: &Duration,
         t1l: &Duration,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        self.encoder = Some(make_bytes_encoder(RMT_CLOCK_HZ, t0h, t0l, t1h, t1l)?);
+        self.encoder = Some(make_bytes_encoder(self.clock_hz, t0h, t0l, t1h, t1l)?);
         Ok(self)
     }
 
@@ -188,7 +199,7 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
             encoder
         } else {
             make_bytes_encoder(
-                RMT_CLOCK_HZ,
+                self.clock_hz,
                 &WS2812_T0H_NS,
                 &WS2812_T0L_NS,
                 &WS2812_T1H_NS,
@@ -255,6 +266,18 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// Returns an error if the RMT driver initialization failed.
     pub fn new(pin: impl OutputPin + 'd) -> Result<Self, Ws2812Esp32RmtDriverError> {
         Ws2812Esp32RmtDriverBuilder::new(pin)?.build()
+    }
+
+    /// Creates a WS2812 ESP32 RMT driver wrapper with a custom `TxChannelConfig`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the RMT driver initialization failed.
+    pub fn new_with_config(
+        pin: impl OutputPin + 'd,
+        config: &TxChannelConfig,
+    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        Ws2812Esp32RmtDriverBuilder::new_with_config(pin, config)?.build()
     }
 
     /// Writes pixel data from a pixel-byte sequence to the IO pin.

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -368,40 +368,4 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         }
         Ok(())
     }
-
-    /// Writes pixel data from a pixel-byte sequence to the IO pin.
-    ///
-    /// Byte count per LED pixel and channel order is not handled by this method.
-    /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
-    ///
-    /// Note that this requires `pixel_sequence` to be [`Box`]ed for an allocation free version see [`Self::write_blocking`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if an RMT driver error occurred.
-    ///
-    /// # Warning
-    ///
-    /// Iteration of `pixel_sequence` happens inside an interrupt handler so beware of side-effects
-    /// that don't work in interrupt handlers.
-    /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter()] for details.
-    #[cfg(feature = "alloc")]
-    pub fn write<'b, T>(
-        &'static mut self,
-        pixel_sequence: T,
-    ) -> Result<(), Ws2812Esp32RmtDriverError>
-    where
-        T: Iterator<Item = u8> + Send + 'static,
-    {
-        #[cfg(target_vendor = "espressif")]
-        {
-            let signal = self.encoder.encode_iter(pixel_sequence);
-            self.tx.start_iter(signal)?;
-        }
-        #[cfg(not(target_vendor = "espressif"))]
-        {
-            self.pixel_data = Some(pixel_sequence.collect());
-        }
-        Ok(())
-    }
 }

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -11,16 +11,22 @@ use core::marker::PhantomData;
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_hal;
 #[cfg(target_vendor = "espressif")]
-use esp_idf_hal::rmt::{PinState, Pulse, Symbol};
+use esp_idf_hal::rmt::{
+    config::TransmitConfig, encoder::BytesEncoderConfig, PinState, Pulse, Symbol,
+};
 use esp_idf_hal::{
     gpio::OutputPin,
-    rmt::{config::TransmitConfig, RmtChannel, TxRmtDriver},
+    rmt::{config::TxChannelConfig, encoder::BytesEncoder, TxChannelDriver},
     units::Hertz,
 };
 
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_sys;
 use esp_idf_sys::EspError;
+
+/// RMT clock resolution used for pulse timing.
+/// TODO: Is it ok to hardcode this? -- this matches HAL examples.
+const RMT_CLOCK_HZ: Hertz = Hertz(10_000_000); // 10 MHz
 
 /// T0H duration time (0 code, high voltage time)
 const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
@@ -31,72 +37,38 @@ const WS2812_T1H_NS: Duration = Duration::from_nanos(800);
 /// T1L duration time (1 code, low voltage time)
 const WS2812_T1L_NS: Duration = Duration::from_nanos(450);
 
-/// Converter to a sequence of RMT items.
-#[repr(C)]
-struct Ws2812Esp32RmtItemEncoder {
-    /// The RMT item that represents a 0 code.
-    #[cfg(target_vendor = "espressif")]
-    bit0: Symbol,
-    /// The RMT item that represents a 1 code.
-    #[cfg(target_vendor = "espressif")]
-    bit1: Symbol,
+#[cfg(target_vendor = "espressif")]
+fn make_bytes_encoder(
+    clock_hz: Hertz,
+    t0h: &Duration,
+    t0l: &Duration,
+    t1h: &Duration,
+    t1l: &Duration,
+) -> Result<BytesEncoder, EspError> {
+    let config = BytesEncoderConfig {
+        bit0: Symbol::new(
+            Pulse::new_with_duration(clock_hz, PinState::High, *t0h)?,
+            Pulse::new_with_duration(clock_hz, PinState::Low, *t0l)?,
+        ),
+        bit1: Symbol::new(
+            Pulse::new_with_duration(clock_hz, PinState::High, *t1h)?,
+            Pulse::new_with_duration(clock_hz, PinState::Low, *t1l)?,
+        ),
+        msb_first: true,
+        ..Default::default()
+    };
+    BytesEncoder::with_config(&config)
 }
 
-impl Ws2812Esp32RmtItemEncoder {
-    /// Creates a new `Ws2812Esp32RmtItemEncoder`.
-    fn new(
-        clock_hz: Hertz,
-        t0h: &Duration,
-        t0l: &Duration,
-        t1h: &Duration,
-        t1l: &Duration,
-    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        #[cfg(target_vendor = "espressif")]
-        {
-            let (bit0, bit1) = (
-                Symbol::new(
-                    Pulse::new_with_duration(clock_hz, PinState::High, &t0h)?,
-                    Pulse::new_with_duration(clock_hz, PinState::Low, &t0l)?,
-                ),
-                Symbol::new(
-                    Pulse::new_with_duration(clock_hz, PinState::High, &t1h)?,
-                    Pulse::new_with_duration(clock_hz, PinState::Low, &t1l)?,
-                ),
-            );
-            Ok(Self { bit0, bit1 })
-        }
-        #[cfg(not(target_vendor = "espressif"))]
-        {
-            let _ = (clock_hz, t0h, t0l, t1h, t1l);
-            Ok(Self {})
-        }
-    }
-    /// Encodes a block of data as a sequence of RMT items.
-    ///
-    /// # Arguments
-    ///
-    /// * `src` - The block of data to encode.
-    ///
-    /// # Returns
-    ///
-    /// An iterator over the RMT items that represent the encoded data.
-    #[inline]
-    #[cfg(target_vendor = "espressif")]
-    fn encode_iter<'a, 'b, T>(&'a self, src: T) -> impl Iterator<Item = Symbol> + Send + 'a
-    where
-        'b: 'a,
-        T: Iterator<Item = u8> + Send + 'b,
-    {
-        src.flat_map(move |v| {
-            (0..(u8::BITS as usize)).map(move |i| {
-                if v & (1 << (7 - i)) != 0 {
-                    self.bit1
-                } else {
-                    self.bit0
-                }
-            })
-        })
-    }
+#[cfg(not(target_vendor = "espressif"))]
+fn make_bytes_encoder(
+    _clock_hz: Hertz,
+    _t0h: &Duration,
+    _t0l: &Duration,
+    _t1h: &Duration,
+    _t1l: &Duration,
+) -> Result<BytesEncoder, EspError> {
+    Ok(BytesEncoder {})
 }
 
 /// WS2812 ESP32 RMT Driver error.
@@ -152,13 +124,10 @@ impl From<EspError> for Ws2812Esp32RmtDriverError {
 /// #
 /// # use core::time::Duration;
 /// # use esp_idf_hal::peripherals::Peripherals;
-/// # use esp_idf_hal::rmt::config::TransmitConfig;
-/// # use esp_idf_hal::rmt::TxRmtDriver;
 /// # use ws2812_esp32_rmt_driver::driver::Ws2812Esp32RmtDriverBuilder;
 /// #
 /// # let peripherals = Peripherals::take().unwrap();
 /// # let led_pin = peripherals.pins.gpio27;
-/// # let channel = peripherals.rmt.channel0;
 ///
 /// // WS2812B timing parameters.
 /// const WS2812_T0H_NS: Duration = Duration::from_nanos(400);
@@ -166,34 +135,25 @@ impl From<EspError> for Ws2812Esp32RmtDriverError {
 /// const WS2812_T1H_NS: Duration = Duration::from_nanos(800);
 /// const WS2812_T1L_NS: Duration = Duration::from_nanos(450);
 ///
-/// let driver_config = TransmitConfig::new()
-///     .clock_divider(1); // Required parameter.
-/// let tx_driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-/// let driver = Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx_driver).unwrap()
+/// let driver = Ws2812Esp32RmtDriverBuilder::new(led_pin).unwrap()
 ///    .encoder_duration(&WS2812_T0H_NS, &WS2812_T0L_NS, &WS2812_T1H_NS, &WS2812_T1L_NS).unwrap()
 ///    .build().unwrap();
 /// ```
 pub struct Ws2812Esp32RmtDriverBuilder<'d> {
     /// TxRMT driver.
-    tx: TxRmtDriver<'d>,
-    /// `u8`-to-`rmt_item32_t` Encoder
-    encoder: Option<Ws2812Esp32RmtItemEncoder>,
+    tx: TxChannelDriver<'d>,
+    /// BytesEncoder with WS2812 timing configuration.
+    encoder: Option<BytesEncoder>,
 }
 
 impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
     /// Creates a new `Ws2812Esp32RmtDriverBuilder`.
-    pub fn new<C: RmtChannel + 'd>(
-        channel: C,
-        pin: impl OutputPin + 'd,
-    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let config = TransmitConfig::new().clock_divider(1);
-        let tx = TxRmtDriver::new(channel, pin, &config)?;
-
-        Self::new_with_rmt_driver(tx)
-    }
-
-    /// Creates a new `Ws2812Esp32RmtDriverBuilder` with `TxRmtDriver`.
-    pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
+    pub fn new(pin: impl OutputPin + 'd) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let config = TxChannelConfig {
+            resolution: RMT_CLOCK_HZ,
+            ..Default::default()
+        };
+        let tx = TxChannelDriver::new(pin, &config)?;
         Ok(Self { tx, encoder: None })
     }
 
@@ -201,11 +161,12 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
     ///
     /// # Arguments
     ///
-    /// * `clock_hz` - The clock frequency.
     /// * `t0h` - T0H duration time (0 code, high voltage time)
     /// * `t0l` - T0L duration time (0 code, low voltage time)
     /// * `t1h` - T1H duration time (1 code, high voltage time)
     /// * `t1l` - T1L duration time (1 code, low voltage time)
+    ///
+    /// Note: the clock resolution is fixed at 10 MHz.
     ///
     /// # Errors
     ///
@@ -217,10 +178,7 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
         t1h: &Duration,
         t1l: &Duration,
     ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let clock_hz = self.tx.counter_clock()?;
-        self.encoder = Some(Ws2812Esp32RmtItemEncoder::new(
-            clock_hz, t0h, t0l, t1h, t1l,
-        )?);
+        self.encoder = Some(make_bytes_encoder(RMT_CLOCK_HZ, t0h, t0l, t1h, t1l)?);
         Ok(self)
     }
 
@@ -229,9 +187,8 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
         let encoder = if let Some(encoder) = self.encoder {
             encoder
         } else {
-            let clock_hz = self.tx.counter_clock()?;
-            Ws2812Esp32RmtItemEncoder::new(
-                clock_hz,
+            make_bytes_encoder(
+                RMT_CLOCK_HZ,
                 &WS2812_T0H_NS,
                 &WS2812_T0L_NS,
                 &WS2812_T1H_NS,
@@ -264,21 +221,20 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
 ///
 /// let peripherals = Peripherals::take().unwrap();
 /// let led_pin = peripherals.pins.gpio27;
-/// let channel = peripherals.rmt.channel0;
-/// let mut driver = Ws2812Esp32RmtDriver::new(channel, led_pin).unwrap();
+/// let mut driver = Ws2812Esp32RmtDriver::new(led_pin).unwrap();
 ///
 /// // Single LED with RED color.
 /// let red = LedPixelColorGrb24::new_with_rgb(30, 0, 0);
 /// let pixel: [u8; 3] = red.as_ref().try_into().unwrap();
 /// assert_eq!(pixel, [0, 30, 0]);
 ///
-/// driver.write_blocking(pixel.clone().into_iter()).unwrap();
+/// driver.write_blocking(core::iter::once(pixel.as_ref())).unwrap();
 /// ```
 pub struct Ws2812Esp32RmtDriver<'d> {
-    /// TxRMT driver.
-    tx: TxRmtDriver<'d>,
-    /// `u8`-to-`rmt_item32_t` Encoder
-    encoder: Ws2812Esp32RmtItemEncoder,
+    /// TxChannelDriver
+    tx: TxChannelDriver<'d>,
+    /// BytesEncoder with WS2812 timing configuration.
+    encoder: BytesEncoder,
 
     /// Pixel binary array to be written
     ///
@@ -294,45 +250,11 @@ pub struct Ws2812Esp32RmtDriver<'d> {
 impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// Creates a WS2812 ESP32 RMT driver wrapper.
     ///
-    /// RMT driver of `channel` shall be initialized and installed for `pin`.
-    /// `channel` shall be different between different `pin`.
-    ///
     /// # Errors
     ///
     /// Returns an error if the RMT driver initialization failed.
-    pub fn new<C: RmtChannel + 'd>(
-        channel: C,
-        pin: impl OutputPin + 'd,
-    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        Ws2812Esp32RmtDriverBuilder::new(channel, pin)?.build()
-    }
-
-    /// Creates a WS2812 ESP32 RMT driver wrapper with `TxRmtDriver`.
-    ///
-    /// The clock divider must be set to 1 for the `driver` configuration.
-    ///
-    /// ```
-    /// # #[cfg(not(target_vendor = "espressif"))]
-    /// # use ws2812_esp32_rmt_driver::mock::esp_idf_hal;
-    /// #
-    /// # use esp_idf_hal::peripherals::Peripherals;
-    /// # use esp_idf_hal::rmt::config::TransmitConfig;
-    /// # use esp_idf_hal::rmt::TxRmtDriver;
-    /// #
-    /// # let peripherals = Peripherals::take().unwrap();
-    /// # let led_pin = peripherals.pins.gpio27;
-    /// # let channel = peripherals.rmt.channel0;
-    /// #
-    /// let driver_config = TransmitConfig::new()
-    ///     .clock_divider(1); // Required parameter.
-    /// let driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the RMT driver initialization failed.
-    pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        Ws2812Esp32RmtDriverBuilder::new_with_rmt_driver(tx)?.build()
+    pub fn new(pin: impl OutputPin + 'd) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        Ws2812Esp32RmtDriverBuilder::new(pin)?.build()
     }
 
     /// Writes pixel data from a pixel-byte sequence to the IO pin.
@@ -343,28 +265,25 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
     /// # Errors
     ///
     /// Returns an error if an RMT driver error occurred.
-    ///
-    /// # Warning
-    ///
-    /// Iteration of `pixel_sequence` happens inside an interrupt handler so beware of side-effects
-    /// that don't work in interrupt handlers.
-    /// See [esp_idf_hal::rmt::TxRmtDriver#start_iter_blocking()] for details.
-    pub fn write_blocking<'a, 'b, T>(
-        &'a mut self,
+    pub fn write_blocking<S, T>(
+        &mut self,
         pixel_sequence: T,
     ) -> Result<(), Ws2812Esp32RmtDriverError>
     where
-        'b: 'a,
-        T: Iterator<Item = u8> + Send + 'b,
+        S: AsRef<[u8]>,
+        T: Iterator<Item = S>,
     {
         #[cfg(target_vendor = "espressif")]
         {
-            let signal = self.encoder.encode_iter(pixel_sequence);
-            self.tx.start_iter_blocking(signal)?;
+            self.tx.send_iter(
+                core::iter::once(&mut self.encoder),
+                pixel_sequence,
+                &TransmitConfig::default(),
+            )?;
         }
         #[cfg(not(target_vendor = "espressif"))]
         {
-            self.pixel_data = Some(pixel_sequence.collect());
+            self.pixel_data = Some(pixel_sequence.flat_map(|s| s.as_ref().to_vec()).collect());
         }
         Ok(())
     }

--- a/src/driver/esp32_rmt.rs
+++ b/src/driver/esp32_rmt.rs
@@ -12,7 +12,7 @@ use core::marker::PhantomData;
 use crate::mock::esp_idf_hal;
 #[cfg(target_vendor = "espressif")]
 use esp_idf_hal::rmt::{
-    config::TransmitConfig, encoder::BytesEncoderConfig, PinState, Pulse, Symbol,
+    config::TransmitConfig, encoder::BytesEncoderConfig, PinState, Pulse, Symbol, TxQueue,
 };
 use esp_idf_hal::{
     gpio::OutputPin,
@@ -218,6 +218,19 @@ impl<'d> Ws2812Esp32RmtDriverBuilder<'d> {
     }
 }
 
+/// An in-progress non-blocking WS2812 transmission.
+///
+/// Dropping this value will block until the transmission is complete.
+#[cfg(target_vendor = "espressif")]
+pub struct Ws2812Esp32RmtTxQueue<'c, 'd> {
+    queue: TxQueue<'c, 'd, &'c mut BytesEncoder>,
+}
+
+#[cfg(not(target_vendor = "espressif"))]
+pub struct Ws2812Esp32RmtTxQueue<'c, 'd> {
+    driver: &'c mut Ws2812Esp32RmtDriver<'d>,
+}
+
 /// WS2812 ESP32 RMT driver wrapper.
 ///
 /// # Examples
@@ -296,17 +309,94 @@ impl<'d> Ws2812Esp32RmtDriver<'d> {
         S: AsRef<[u8]>,
         T: Iterator<Item = S>,
     {
+        self.queue().push_seq_blocking(pixel_sequence)?;
+        Ok(())
+    }
+
+    /// Creates a new queue to transmit multiple symbols.
+    ///
+    /// This is mostly useful for non-blocking transmission, but it can also be used
+    /// for blocking transmission if then the caller wants to reuse the same queue for
+    /// multiple transmissions.
+    ///
+    /// Note: Dropping the queue will block until the transmission is complete,
+    /// so be careful to not drop the queue prematurely.
+    pub fn queue<'a>(&'a mut self) -> Ws2812Esp32RmtTxQueue<'a, 'd> {
         #[cfg(target_vendor = "espressif")]
         {
-            self.tx.send_iter(
-                core::iter::once(&mut self.encoder),
-                pixel_sequence,
-                &TransmitConfig::default(),
-            )?;
+            let queue = self.tx.queue(core::iter::once(&mut self.encoder));
+            Ws2812Esp32RmtTxQueue { queue }
         }
         #[cfg(not(target_vendor = "espressif"))]
         {
-            self.pixel_data = Some(pixel_sequence.flat_map(|s| s.as_ref().to_vec()).collect());
+            Ws2812Esp32RmtTxQueue { driver: self }
+        }
+    }
+}
+
+impl<'c, 'd> Ws2812Esp32RmtTxQueue<'c, 'd> {
+    /// Writes pixel data to the IO pin, using a pre-made queue, without blocking.
+    ///
+    /// Byte count per LED pixel and channel order is not handled by this method.
+    /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an RMT driver error occurred, for example if the data cannot
+    /// be pushed to the transmission queue without blocking.
+    pub fn push(&mut self, pixel: &[u8]) -> Result<(), Ws2812Esp32RmtDriverError> {
+        #[cfg(target_vendor = "espressif")]
+        {
+            let config = TransmitConfig {
+                queue_non_blocking: true,
+                ..Default::default()
+            };
+            self.queue.push(pixel, &config)?;
+        }
+        #[cfg(not(target_vendor = "espressif"))]
+        {
+            self.driver.pixel_data = Some(pixel.to_vec());
+        }
+        Ok(())
+    }
+
+    /// Writes pixel data to the IO pin, using a pre-made queue, blocking.
+    ///
+    /// Byte count per LED pixel and channel order is not handled by this method.
+    /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an RMT driver error occurred.
+    pub fn push_blocking(&mut self, pixel: &[u8]) -> Result<(), Ws2812Esp32RmtDriverError> {
+        #[cfg(target_vendor = "espressif")]
+        self.queue.push(pixel, &TransmitConfig::default())?;
+        #[cfg(not(target_vendor = "espressif"))]
+        {
+            self.driver.pixel_data = Some(pixel.to_vec());
+        }
+        Ok(())
+    }
+
+    /// Writes pixel data from a pixel-byte sequence to the IO pin using a pre-made queue,
+    /// blocking.
+    ///
+    /// Byte count per LED pixel and channel order is not handled by this method.
+    /// The pixel data sequence has to be correctly laid out depending on the LED strip model.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an RMT driver error occurred.
+    pub fn push_seq_blocking<S, T>(
+        &mut self,
+        pixel_sequence: T,
+    ) -> Result<(), Ws2812Esp32RmtDriverError>
+    where
+        S: AsRef<[u8]>,
+        T: Iterator<Item = S>,
+    {
+        for signal in pixel_sequence {
+            self.push_blocking(signal.as_ref())?;
         }
         Ok(())
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -6,3 +6,4 @@ mod esp32_rmt;
 pub use esp32_rmt::Ws2812Esp32RmtDriver;
 pub use esp32_rmt::Ws2812Esp32RmtDriverBuilder;
 pub use esp32_rmt::Ws2812Esp32RmtDriverError;
+pub use esp32_rmt::Ws2812Esp32RmtTxQueue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 pub mod driver;

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -61,13 +61,8 @@ impl<const W: usize, const H: usize> LedPixelShape for LedPixelMatrix<W, H> {
 type LedPixelDrawTargetData = Vec<u8>;
 
 /// Default data storage type for `LedPixelDrawTarget`.
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(not(feature = "std"))]
 type LedPixelDrawTargetData = alloc::vec::Vec<u8>;
-
-/// Default data storage type for `LedPixelDrawTarget`.
-/// In case of heapless, allocate 256-byte capacity vector.
-#[cfg(all(not(feature = "std"), not(feature = "alloc")))]
-type LedPixelDrawTargetData = heapless::Vec<u8, 256>;
 
 /// Target for embedded-graphics drawing operations of the LED pixels.
 ///
@@ -80,9 +75,6 @@ type LedPixelDrawTargetData = heapless::Vec<u8, 256>;
 /// * `Data` - (optional) data storage type. It shall be `Vec`-like struct.
 ///
 /// [`flush()`] operation shall be required to write changes from a framebuffer to the display.
-///
-/// For non-`alloc` no_std environment, `Data` should be explicitly set to some `Vec`-like struct:
-/// e.g., `heapless::Vec<u8, PIXEL_LEN>` where `PIXEL_LEN` equals to `S::size() * CDev::BPP`.
 ///
 /// [`flush()`]: #method.flush
 pub struct LedPixelDrawTarget<'d, CDraw, CDev, S, Data = LedPixelDrawTargetData>
@@ -233,9 +225,6 @@ pub type LedPixelStrip<const L: usize> = LedPixelMatrix<L, 1>;
 ///
 /// [`flush()`] operation shall be required to write changes from a framebuffer to the display.
 ///
-/// For non-`alloc` no_std environment, `Data` should be explicitly set to some `Vec`-like struct:
-/// e.g., `heapless::Vec<u8, PIXEL_LEN>` where `PIXEL_LEN` equals to `S::size() * LedPixelColorGrb24::BPP`.
-///
 /// [`flush()`]: #method.flush
 ///
 /// # Examples
@@ -323,26 +312,6 @@ mod test {
         assert_eq!(
             draw.data,
             core::iter::repeat(0).take(150).collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
-    fn test_ws2812draw_target_new_with_custom_data_struct() {
-        const VEC_CAPACITY: usize = LedPixelMatrix::<10, 5>::PIXEL_LEN * LedPixelColorGrb24::BPP;
-
-        let peripherals = Peripherals::take().unwrap();
-        let led_pin = peripherals.pins.gpio0;
-
-        let draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>, heapless::Vec<u8, VEC_CAPACITY>>::new(
-            led_pin,
-        )
-        .unwrap();
-        assert_eq!(draw.changed, true);
-        assert_eq!(
-            draw.data,
-            core::iter::repeat(0)
-                .take(150)
-                .collect::<heapless::Vec<_, VEC_CAPACITY>>()
         );
     }
 

--- a/src/lib_embedded_graphics.rs
+++ b/src/lib_embedded_graphics.rs
@@ -8,11 +8,10 @@ use embedded_graphics_core::draw_target::DrawTarget;
 use embedded_graphics_core::geometry::{OriginDimensions, Point, Size};
 use embedded_graphics_core::pixelcolor::{Rgb888, RgbColor};
 use embedded_graphics_core::Pixel;
-use esp_idf_hal::rmt::TxRmtDriver;
 
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_hal;
-use esp_idf_hal::{gpio::OutputPin, rmt::RmtChannel};
+use esp_idf_hal::gpio::OutputPin;
 
 /// LED pixel shape
 pub trait LedPixelShape {
@@ -108,38 +107,8 @@ where
     Data: DerefMut<Target = [u8]> + FromIterator<u8> + IntoIterator<Item = u8>,
 {
     /// Create a new draw target.
-    ///
-    /// `channel` shall be different between different `pin`.
-    pub fn new<C: RmtChannel + 'd>(
-        channel: C,
-        pin: impl OutputPin + 'd,
-    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let driver = Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?;
-        Self::new_with_ws2812_driver(driver)
-    }
-
-    /// Create a new draw target with `TxRmtDriver`.
-    ///
-    /// The clock divider must be set to 1 for the `driver` configuration.
-    ///
-    /// ```
-    /// # #[cfg(not(target_vendor = "espressif"))]
-    /// # use ws2812_esp32_rmt_driver::mock::esp_idf_hal;
-    /// #
-    /// # use esp_idf_hal::peripherals::Peripherals;
-    /// # use esp_idf_hal::rmt::config::TransmitConfig;
-    /// # use esp_idf_hal::rmt::TxRmtDriver;
-    /// #
-    /// # let peripherals = Peripherals::take().unwrap();
-    /// # let led_pin = peripherals.pins.gpio27;
-    /// # let channel = peripherals.rmt.channel0;
-    /// #
-    /// let driver_config = TransmitConfig::new()
-    ///     .clock_divider(1); // Required parameter.
-    /// let driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-    /// ```
-    pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        let driver = Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?;
+    pub fn new(pin: impl OutputPin + 'd) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        let driver = Ws2812Esp32RmtDriver::<'d>::new(pin)?;
         Self::new_with_ws2812_driver(driver)
     }
 
@@ -183,7 +152,8 @@ where
     /// Write changes from a framebuffer to the LED pixels
     pub fn flush(&mut self) -> Result<(), Ws2812Esp32RmtDriverError> {
         if self.changed {
-            self.driver.write_blocking(self.data.iter().copied())?;
+            self.driver
+                .write_blocking(core::iter::once(self.data.as_ref()))?;
             self.changed = false;
         }
         Ok(())
@@ -282,8 +252,7 @@ pub type LedPixelStrip<const L: usize> = LedPixelMatrix<L, 1>;
 ///
 /// let peripherals = Peripherals::take().unwrap();
 /// let led_pin = peripherals.pins.gpio27;
-/// let channel = peripherals.rmt.channel0;
-/// let mut draw = Ws2812DrawTarget::<LedPixelMatrix<5, 5>>::new(channel, led_pin).unwrap();
+/// let mut draw = Ws2812DrawTarget::<LedPixelMatrix<5, 5>>::new(led_pin).unwrap();
 /// draw.set_brightness(40);
 /// draw.clear_with_black().unwrap();
 /// let mut translated_draw = draw.translated(Point::new(0, 0));
@@ -348,9 +317,8 @@ mod test {
     fn test_ws2812draw_target_new() {
         let peripherals = Peripherals::take().unwrap();
         let led_pin = peripherals.pins.gpio0;
-        let channel = peripherals.rmt.channel0;
 
-        let draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>>::new(channel, led_pin).unwrap();
+        let draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>>::new(led_pin).unwrap();
         assert_eq!(draw.changed, true);
         assert_eq!(
             draw.data,
@@ -364,10 +332,9 @@ mod test {
 
         let peripherals = Peripherals::take().unwrap();
         let led_pin = peripherals.pins.gpio0;
-        let channel = peripherals.rmt.channel0;
 
         let draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>, heapless::Vec<u8, VEC_CAPACITY>>::new(
-            channel, led_pin,
+            led_pin,
         )
         .unwrap();
         assert_eq!(draw.changed, true);
@@ -383,9 +350,8 @@ mod test {
     fn test_ws2812draw_target_draw() {
         let peripherals = Peripherals::take().unwrap();
         let led_pin = peripherals.pins.gpio1;
-        let channel = peripherals.rmt.channel1;
 
-        let mut draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>>::new(channel, led_pin).unwrap();
+        let mut draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>>::new(led_pin).unwrap();
 
         draw.draw_iter(
             [
@@ -424,9 +390,8 @@ mod test {
     fn test_ws2812draw_target_flush() {
         let peripherals = Peripherals::take().unwrap();
         let led_pin = peripherals.pins.gpio2;
-        let channel = peripherals.rmt.channel2;
 
-        let mut draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>>::new(channel, led_pin).unwrap();
+        let mut draw = Ws2812DrawTarget::<LedPixelMatrix<10, 5>>::new(led_pin).unwrap();
 
         draw.changed = true;
         draw.data.fill(0x01);

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -2,10 +2,9 @@
 
 use crate::driver::color::{LedPixelColor, LedPixelColorGrb24, LedPixelColorImpl};
 use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-#[cfg(feature = "alloc")]
 use smart_leds_trait::SmartLedsWrite;
 use smart_leds_trait::{RGB8, RGBW};
 
@@ -125,7 +124,6 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<'d, CSmart, CDev> SmartLedsWrite for LedPixelEsp32Rmt<'d, CSmart, CDev>
 where
     CDev: LedPixelColor + From<CSmart>,

--- a/src/lib_smart_leds.rs
+++ b/src/lib_smart_leds.rs
@@ -5,14 +5,13 @@ use crate::driver::{Ws2812Esp32RmtDriver, Ws2812Esp32RmtDriverError};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-use esp_idf_hal::rmt::TxRmtDriver;
 #[cfg(feature = "alloc")]
 use smart_leds_trait::SmartLedsWrite;
 use smart_leds_trait::{RGB8, RGBW};
 
 #[cfg(not(target_vendor = "espressif"))]
 use crate::mock::esp_idf_hal;
-use esp_idf_hal::{gpio::OutputPin, rmt::RmtChannel};
+use esp_idf_hal::gpio::OutputPin;
 
 /// 8-bit RGBW (RGB + white)
 pub type RGBW8 = RGBW<u8, u8>;
@@ -61,8 +60,7 @@ impl<
 ///
 /// let peripherals = Peripherals::take().unwrap();
 /// let led_pin = peripherals.pins.gpio26;
-/// let channel = peripherals.rmt.channel0;
-/// let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(channel, led_pin).unwrap();
+/// let mut ws2812 = LedPixelEsp32Rmt::<RGBW8, LedPixelColorGrbw32>::new(led_pin).unwrap();
 ///
 /// let pixels = std::iter::repeat(RGBW8 {r: 0, g: 0, b: 0, a: White(30)}).take(25);
 /// ws2812.write(pixels).unwrap();
@@ -80,37 +78,8 @@ where
     CDev: LedPixelColor + From<CSmart>,
 {
     /// Create a new driver wrapper.
-    ///
-    /// `channel` shall be different between different `pin`.
-    pub fn new<C: RmtChannel + 'd>(
-        channel: C,
-        pin: impl OutputPin + 'd,
-    ) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new(channel, pin)?)
-    }
-
-    /// Create a new driver wrapper with `TxRmtDriver`.
-    ///
-    /// The clock divider must be set to 1 for the `driver` configuration.
-    ///
-    /// ```
-    /// # #[cfg(not(target_vendor = "espressif"))]
-    /// # use ws2812_esp32_rmt_driver::mock::esp_idf_hal;
-    /// #
-    /// # use esp_idf_hal::peripherals::Peripherals;
-    /// # use esp_idf_hal::rmt::config::TransmitConfig;
-    /// # use esp_idf_hal::rmt::TxRmtDriver;
-    /// #
-    /// # let peripherals = Peripherals::take().unwrap();
-    /// # let led_pin = peripherals.pins.gpio27;
-    /// # let channel = peripherals.rmt.channel0;
-    /// #
-    /// let driver_config = TransmitConfig::new()
-    ///     .clock_divider(1); // Required parameter.
-    /// let driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-    /// ```
-    pub fn new_with_rmt_driver(tx: TxRmtDriver<'d>) -> Result<Self, Ws2812Esp32RmtDriverError> {
-        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new_with_rmt_driver(tx)?)
+    pub fn new(pin: impl OutputPin + 'd) -> Result<Self, Ws2812Esp32RmtDriverError> {
+        Self::new_with_ws2812_driver(Ws2812Esp32RmtDriver::<'d>::new(pin)?)
     }
 
     /// Create a new driver wrapper with `Ws2812Esp32RmtDriver`.
@@ -145,10 +114,9 @@ where
     where
         T: IntoIterator<Item = I>,
         I: Into<CSmart>,
-        <T as IntoIterator>::IntoIter: Send,
     {
         self.driver
-            .write_blocking(iterator.into_iter().flat_map(|color| {
+            .write_blocking(iterator.into_iter().map(|color| {
                 let c =
                     LedPixelColorImpl::<N, R_ORDER, G_ORDER, B_ORDER, W_ORDER>::from(color.into());
                 c.0
@@ -179,7 +147,8 @@ where
             vec.extend_from_slice(CDev::from(color.into()).as_ref());
             vec
         });
-        self.driver.write_blocking(pixel_data.into_iter())?;
+        self.driver
+            .write_blocking(core::iter::once(pixel_data.as_slice()))?;
         Ok(())
     }
 }
@@ -199,46 +168,12 @@ where
 ///
 /// let peripherals = Peripherals::take().unwrap();
 /// let led_pin = peripherals.pins.gpio27;
-/// let channel = peripherals.rmt.channel0;
-/// let mut ws2812 = Ws2812Esp32Rmt::new(channel, led_pin).unwrap();
+/// let mut ws2812 = Ws2812Esp32Rmt::new(led_pin).unwrap();
 ///
 /// let pixels = std::iter::repeat(RGB8::new(30, 0, 0)).take(25);
 /// ws2812.write(pixels).unwrap();
 /// ```
 ///
-/// The LED colors may flicker randomly when using Wi-Fi or Bluetooth with Ws2812 LEDs.
-/// This issue can be resolved by:
-///
-/// - Separating Wi-Fi/Bluetooth processing from LED control onto different cores.
-/// - Use multiple memory blocks (memory symbols) in the RMT driver.
-///
-/// To do the second option, prepare `TxRmtDriver` yourself and
-/// initialize with [`Self::new_with_rmt_driver`] as shown below.
-///
-/// ```
-/// # #[cfg(not(target_vendor = "espressif"))]
-/// # use ws2812_esp32_rmt_driver::mock::esp_idf_hal;
-/// #
-/// # use esp_idf_hal::peripherals::Peripherals;
-/// # use esp_idf_hal::rmt::config::TransmitConfig;
-/// # use esp_idf_hal::rmt::TxRmtDriver;
-/// # use smart_leds::{RGB8, SmartLedsWrite};
-/// # use ws2812_esp32_rmt_driver::Ws2812Esp32Rmt;
-/// #
-/// # let peripherals = Peripherals::take().unwrap();
-/// # let led_pin = peripherals.pins.gpio27;
-/// # let channel = peripherals.rmt.channel0;
-/// #
-/// let driver_config = TransmitConfig::new()
-///     .clock_divider(1)  // Required parameter.
-///     .mem_block_num(2); // Increase the number depending on your code.
-/// let driver = TxRmtDriver::new(channel, led_pin, &driver_config).unwrap();
-///
-/// let mut ws2812 = Ws2812Esp32Rmt::new_with_rmt_driver(driver).unwrap();
-/// #
-/// # let pixels = std::iter::repeat(RGB8::new(30, 0, 0)).take(25);
-/// # ws2812.write(pixels).unwrap();
-/// ```
 pub type Ws2812Esp32Rmt<'d> = LedPixelEsp32Rmt<'d, RGB8, LedPixelColorGrb24>;
 
 #[cfg(test)]
@@ -253,9 +188,8 @@ mod test {
 
         let peripherals = Peripherals::take().unwrap();
         let led_pin = peripherals.pins.gpio0;
-        let channel = peripherals.rmt.channel0;
 
-        let mut ws2812 = Ws2812Esp32Rmt::new(channel, led_pin).unwrap();
+        let mut ws2812 = Ws2812Esp32Rmt::new(led_pin).unwrap();
         ws2812.write(sample_data.iter().cloned()).unwrap();
         assert_eq!(ws2812.driver.pixel_data.unwrap(), &expected_values);
     }

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -87,7 +87,7 @@ pub mod esp_idf_hal {
     pub mod rmt {
         use super::gpio::OutputPin;
         use super::sys::EspError;
-        use config::{TransmitConfig, TxChannelConfig};
+        use config::TxChannelConfig;
         use core::marker::PhantomData;
 
         /// Mock struct for `esp_idf_hal::rmt::TxChannelDriver`
@@ -103,15 +103,6 @@ pub mod esp_idf_hal {
                 _config: &TxChannelConfig,
             ) -> Result<Self, EspError> {
                 Ok(Self { _p: PhantomData })
-            }
-
-            pub fn send_iter<S: AsRef<[u8]>>(
-                &mut self,
-                _encoders: impl IntoIterator<Item = &'d mut encoder::BytesEncoder>,
-                _iter: impl Iterator<Item = S>,
-                _config: &TransmitConfig,
-            ) -> Result<(), EspError> {
-                Ok(())
             }
         }
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -44,12 +44,6 @@ pub mod esp_idf_hal {
                         #[derive(Debug, Default)]
                         pub struct [<Gpio $num>] {}
 
-                        //impl [<Gpio $num>] {
-                        //    pub(super) fn new() -> Self {
-                        //        Self {}
-                        //    }
-                        //}
-
                         impl OutputPin for [<Gpio $num>] {}
                     )*
                 }
@@ -65,12 +59,10 @@ pub mod esp_idf_hal {
     /// Mock module for `esp_idf_hal::peripherals`
     pub mod peripherals {
         use super::gpio;
-        use super::rmt;
 
         /// Mock struct for `esp_idf_hal::peripherals::Peripherals`
         pub struct Peripherals {
             pub pins: gpio::Pins,
-            pub rmt: rmt::RMT,
         }
 
         impl Peripherals {
@@ -86,7 +78,6 @@ pub mod esp_idf_hal {
             pub fn new() -> Self {
                 Self {
                     pins: gpio::Pins::new(),
-                    rmt: rmt::RMT::new(),
                 }
             }
         }
@@ -96,106 +87,60 @@ pub mod esp_idf_hal {
     pub mod rmt {
         use super::gpio::OutputPin;
         use super::sys::EspError;
-        use super::units::Hertz;
-        use config::TransmitConfig;
+        use config::{TransmitConfig, TxChannelConfig};
         use core::marker::PhantomData;
-        use paste::paste;
 
-        macro_rules! define_channel_structs {
-            ($($num:expr),*) => {
-                paste! {
-                    $(
-                        #[doc = concat!("Mock struct for `esp_idf_hal::rmt::CHANNEL", stringify!($num) ,"`")]
-                        #[derive(Debug, Default)]
-                        pub struct [<CHANNEL $num>] {}
-
-                        impl [<CHANNEL $num>] {
-                            pub fn new() -> Self {
-                                Self {}
-                            }
-                        }
-
-                        impl RmtChannel for [<CHANNEL $num>] {}
-                    )*
-                }
-            };
-        }
-        define_channel_structs!(0, 1, 2, 3, 4, 5, 6, 7);
-
-        /// mock struct for `esp_idf_hal::rmt::RMT`
-        #[derive(Debug, Default)]
-        pub struct RMT {
-            pub channel0: CHANNEL0,
-            pub channel1: CHANNEL1,
-            pub channel2: CHANNEL2,
-            pub channel3: CHANNEL3,
-            pub channel4: CHANNEL4,
-            pub channel5: CHANNEL5,
-            pub channel6: CHANNEL6,
-            pub channel7: CHANNEL7,
-        }
-
-        impl RMT {
-            pub fn new() -> Self {
-                Default::default()
-            }
-        }
-
-        /// Mock trait fo `esp_idf_hal::rmt::RmtChannel`
-        pub trait RmtChannel {}
-
-        //pub type RmtTransmitConfig = config::TransmitConfig;
-
-        /// Mock module for `esp_idf_hal::rmt::TxRmtDriver`
-        pub struct TxRmtDriver<'d> {
+        /// Mock struct for `esp_idf_hal::rmt::TxChannelDriver`
+        pub struct TxChannelDriver<'d> {
             _p: PhantomData<&'d mut ()>,
         }
 
-        impl<'d> TxRmtDriver<'d> {
-            /// Initialize the mock of `TxRmtDriver`.
+        impl<'d> TxChannelDriver<'d> {
+            /// Initialize the mock of `TxChannelDriver`.
             /// No argument is used in this mock.
-            pub fn new<C: RmtChannel + 'd>(
-                _channel: C,
+            pub fn new(
                 _pin: impl OutputPin + 'd,
-                _config: &TransmitConfig,
+                _config: &TxChannelConfig,
             ) -> Result<Self, EspError> {
                 Ok(Self { _p: PhantomData })
             }
 
-            pub fn counter_clock(&self) -> Result<Hertz, EspError> {
-                let ticks_hz: u32 = 80000000; // 80MHz
-                Ok(Hertz(ticks_hz))
+            pub fn send_iter<S: AsRef<[u8]>>(
+                &mut self,
+                _encoders: impl IntoIterator<Item = &'d mut encoder::BytesEncoder>,
+                _iter: impl Iterator<Item = S>,
+                _config: &TransmitConfig,
+            ) -> Result<(), EspError> {
+                Ok(())
             }
         }
 
-        /// Mock module for `esp_idf_hal::rmt::config`
+        /// Mock module for `esp_idf_hal::rmt::encoder`
+        pub mod encoder {
+            pub struct BytesEncoder {}
+        }
+
+        /// Mock struct for `esp_idf_hal::rmt::config`
         pub mod config {
-            /// Mock struct for `esp_idf_hal::rmt::config::TransmitConfig`
+            use super::super::units::Hertz;
+
+            /// Mock struct for `esp_idf_hal::rmt::config::TxChannelConfig`
             #[derive(Debug, Clone)]
-            pub struct TransmitConfig {
-                pub clock_divider: u8,
-                pub mem_block_num: u8,
-                // Other parameters are omitted
+            pub struct TxChannelConfig {
+                pub resolution: Hertz,
             }
 
-            impl TransmitConfig {
-                pub fn new() -> Self {
+            impl Default for TxChannelConfig {
+                fn default() -> Self {
                     Self {
-                        mem_block_num: 1,
-                        clock_divider: 80,
+                        resolution: Hertz(10_000_000),
                     }
                 }
-                #[must_use]
-                pub fn clock_divider(mut self, divider: u8) -> Self {
-                    self.clock_divider = divider;
-                    self
-                }
-                #[must_use]
-                pub fn mem_block_num(mut self, mem_block_num: u8) -> Self {
-                    self.mem_block_num = mem_block_num;
-                    self
-                }
             }
+
+            /// Mock struct for `esp_idf_hal::rmt::config::TransmitConfig`
+            #[derive(Debug, Clone, Default)]
+            pub struct TransmitConfig {}
         }
     }
 
@@ -205,7 +150,7 @@ pub mod esp_idf_hal {
         pub type LargeValueType = u64;
 
         /// Mock struct for `esp_idf_hal::units::Hertz`
-        #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Default)]
+        #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Default, Debug)]
         pub struct Hertz(pub ValueType);
     }
 }


### PR DESCRIPTION
Stacks on top of https://github.com/cat-in-136/ws2812-esp32-rmt-driver/pull/69

This was a bit tricky, but I think this is quite stable, and LED control works well when Wifi enabled. I removed `new_with_tx_channel_driver` functions, along with existing comments that used to say this was useful when Wifi was enabled -- I found the new API seems to handle this well enough with default settings? (at least with that single LED on ESP32C6 VROOM board).

I also ended up deleting non-`alloc` path, as the new `rmt` API doesn't support that (see commit message below too).

Again, made with Claude's help, and naturally this required serious hand-holding.

---

### Cargo/config.toml: Add support for ESP32-C6

Also, the queue_nonblocking example requires svc for UART support.

### examples: Add queue_nonblocking example

Demonstrates Ws2812Esp32RmtDriver::queue() and Ws2812Esp32RmtTxQueue:
- push() for non-blocking submission (may return ESP_ERR_TIMEOUT if the
  previous transmission is still in progress)
- push_blocking() for blocking submission
- A realistic use case: push() then do other work while the transmission
  runs, relying on drop to wait for completion.

Output looks like this:
```
I (492) queue_nonblocking: Calling push(), brightness=20
I (492) queue_nonblocking: Transmission failed 41 times after initial success.
I (492) queue_nonblocking: Calling push_blocking(), brightness=20
I (492) queue_nonblocking: Blocking: Transmission succeeded immediately after initial success.
I (502) queue_nonblocking: Calling write(), brightness=20
I (512) queue_nonblocking: Transmission started, doing other work...
I (622) queue_nonblocking: Calling push(), brightness=40
```

### Add Ws2812Esp32RmtTxQueue for non-blocking and reusable transmission

- Add Ws2812Esp32RmtDriver::queue() which returns a Ws2812Esp32RmtTxQueue
  borrowing the driver. Dropping the queue blocks until transmission completes.
- Add Ws2812Esp32RmtTxQueue::push() for non-blocking submission
  (returns ESP_ERR_TIMEOUT if the RMT queue is full).
- Add Ws2812Esp32RmtTxQueue::push_blocking() and push_seq_blocking()
  for blocking submission.
- write_blocking() is now implemented via queue().push_seq_blocking(),
  this is identical to what esp-idf-hal send_iter did behind the scenes.
- On non-espressif targets, the mock queue stores pixel data directly
  on the driver for inspection in tests.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### Add new_with_config constructors to allow custom TxChannelConfig

Builder and driver both gain new_with_config() taking a &TxChannelConfig,
so callers can set resolution and other RMT channel parameters. The clock
resolution is stored in the builder and used for encoder timing instead of
the hardcoded constant.

Also restore frequency selection in examples/smart_leds_pl9823_rgb.rs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### examples: Fix for new API

No more rmt channel, just a pin.

### Make "alloc" mandatory as the new rmt API requires it.

See https://github.com/esp-rs/esp-idf-hal/pull/548, somewhere
in the thread it was decided that alloc was necessary (esp-idf
does internal allocations anyway), along with a claim that
rmt-legacy is fundamentally broken.

### Migrate from rmt-legacy to new RMT API in esp-idf-hal 0.46

 - We drop the channel argument everywhere, as the new API only
   requires a pin.
   - Also dropped new_with_tx_channel_driver functions, as it makes
     little sense now. We _might_ want to consider adding a config
     parameter (frequency is hardcoded to 10Mhz, for example), but
     I'm not sure if this is necessary.
 - The main change is in write_blocking, where we change parameter
   type to match what send_iter takes.
   - During testing, I noticed it is very important that the whole
     slice is passed at once, otherwise, `send_iter` does multiple
     iterations and the LED does not behave correctly if Wifi is
     enabled.
   - As part of this, replace manual bit encoding with BytesEncoder
     from esp-idf-hal -- simplifies the code!

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### Update ESP_IDF_VERSION to v5.5

We need this for the new rmt API -- arguably 5.3 should be enough,
but 5.5 is the highest version currently tested in CI in esp-idf-hal.

### esp32_rmt: Remove non-blocking "write" function

We do not use it anywhere, and it makes things a little bit easier
when converting from rmt-legacy to rmt, as that's one less thing
to think about.